### PR TITLE
runtime.sgml查看修改后的建议

### DIFF
--- a/postgresql/doc/src/sgml/runtime.sgml
+++ b/postgresql/doc/src/sgml/runtime.sgml
@@ -2032,7 +2032,7 @@ Out of Memory: Killed process 12345 (postgres).
 在某些情况下，调低内存相关的配置参数可能有所帮助，尤其是<link linkend="guc-shared-buffers"><varname>shared_buffers</></link>
 和<link linkend="guc-work-mem"><varname>work_mem</></link>。其他情况下，
 这个问题可能是由于允许太多的连接连到数据库服务器引起的。在许多情况下，
-减小<link linkend="guc-max-connections"><varname>max_connections</></link>会更好，而不是利用外部连接池软件。
+减小<link linkend="guc-max-connections"><varname>max_connections</></link>并且改为使用外部连接池软件会更好。
 </para>
 
    

--- a/postgresql/doc/src/sgml/runtime.sgml
+++ b/postgresql/doc/src/sgml/runtime.sgml
@@ -2032,8 +2032,7 @@ Out of Memory: Killed process 12345 (postgres).
 在某些情况下，调低内存相关的配置参数可能有所帮助，尤其是<link linkend="guc-shared-buffers"><varname>shared_buffers</></link>
 和<link linkend="guc-work-mem"><varname>work_mem</></link>。其他情况下，
 这个问题可能是由于允许太多的连接连到数据库服务器引起的。在许多情况下，
-减小<link linkend="guc-max-connections"><varname>max_connections</></link>
-，并且作为替代，利用外部连接池软件会更好。
+减小<link linkend="guc-max-connections"><varname>max_connections</></link>会更好，而不是利用外部连接池软件。
 </para>
 
    


### PR DESCRIPTION
In many cases, it may be better to reduce
    <link linkend="guc-max-connections"><varname>max_connections</></link>
    and instead make use of external connection-pooling software.
在许多情况下，
减小<link linkend="guc-max-connections"><varname>max_connections</></link>并且改为使用外部连接池软件会更好。