### PR TITLE
纠正maintenance.sgml中一处会引起歧义的index-only的翻译

### DIFF
--- a/postgresql/doc/src/sgml/maintenance.sgml
+++ b/postgresql/doc/src/sgml/maintenance.sgml
@@ -180,7 +180,7 @@
       <simpara>To update the visibility map, which speeds up index-only
       scans.</simpara>
   -->
-  <simpara>更新可见性映射，这加速了唯一索引扫描</simpara>  
+  <simpara>更新可见性映射，这加速了index-only扫描</simpara>  
      </listitem>
 
      <listitem>


### PR DESCRIPTION
“唯一索引”有别的含义，所以改回成英文index-only