### PR TITLE
去除indices.sgml中冗余的英文

### DIFF
--- a/postgresql/doc/src/sgml/indices.sgml
+++ b/postgresql/doc/src/sgml/indices.sgml
@@ -687,7 +687,7 @@ CREATE INDEX test1c_content_y_index ON test1c (content COLLATE "y");
   </indexterm>
 
   <para>
-   Although indexes in 尽管<productname>PostgreSQL</>中的索引并不需要维护或调优，但是检查真实的查询负载实际使用了哪些索引仍然非常重要。检查一个独立查询的索引使用情况可以使用<xref linkend="sql-explain">命令，它应用于这种目的的内容在<xref linkend="using-explain">中有介绍。也可以在一个运行中的服务器上收集有关索引使用的总体统计情况，如<xref linkend="monitoring-stats">所述。
+   尽管<productname>PostgreSQL</>中的索引并不需要维护或调优，但是检查真实的查询负载实际使用了哪些索引仍然非常重要。检查一个独立查询的索引使用情况可以使用<xref linkend="sql-explain">命令，它应用于这种目的的内容在<xref linkend="using-explain">中有介绍。也可以在一个运行中的服务器上收集有关索引使用的总体统计情况，如<xref linkend="monitoring-stats">所述。
   </para>
 
   <para>


### PR DESCRIPTION
去除在翻译过程中遗留的原文
