### PR TITLE
《在表之间连接》的一句话的翻译问题

### DIFF
--- a/postgresql/doc/src/sgml/query.sgml
+++ b/postgresql/doc/src/sgml/query.sgml
@@ -1084,7 +1084,7 @@ ____________________________________________________________________________-->
     <indexterm><primary>join</primary><secondary>self</secondary></indexterm>
     <indexterm><primary>alias</primary><secondary>for table name in query</secondary></indexterm>
 
-    我们也可以把一个表和自己连接起来。这叫做<firstterm>自连接</firstterm>。 比如，假设我们想找出那些在其它天气记录的温度范围之外的天气记录。这样我们就需要拿 <structname>weather</structname>表里每行的<structfield>temp_lo</>和<structfield>temp_hi</>列与<structname>weather</structname>表里其它行的<structfield>temp_lo</>和<structfield>temp_hi</>列进行比较。我们可以用下面的查询实现这个目标：
+    我们也可以把一个表和自己连接起来。这叫做<firstterm>自连接</firstterm>。 比如，假设我们想找出温度范围在其他天气记录范围之内的天气记录。这样我们就需要拿 <structname>weather</structname>表里每行的<structfield>temp_lo</>和<structfield>temp_hi</>列与<structname>weather</structname>表里其它行的<structfield>temp_lo</>和<structfield>temp_hi</>列进行比较。我们可以用下面的查询实现这个目标：
 
 <programlisting>
 SELECT W1.city, W1.temp_lo AS low, W1.temp_hi AS high,


### PR DESCRIPTION
原文档为：
>  As an example, suppose we wish to find all the weather records that are in the temperature range of other weather records.
网站上的翻译为：
> 比如，假设我们想找出那些在其它天气记录的温度范围之外的天气记录。
似乎应该改为：
> 比如，假设我们想找出温度范围在其他天气记录范围之内的天气记录。
更加合适，以免造成歧义。