### PR TITLE
Update revoke.sgml

### DIFF
--- a/postgresql/doc/src/sgml/ref/revoke.sgml
+++ b/postgresql/doc/src/sgml/ref/revoke.sgml
@@ -3,7 +3,7 @@ doc/src/sgml/ref/revoke.sgml
 PostgreSQL documentation
 -->
 
-<refentry id="SQL-REVOKE">
+<refentry id="sql-revoke">
 <!--==========================orignal english content==========================
  <indexterm zone="sql-revoke">
   <primary>REVOKE</primary>
@@ -89,8 +89,8 @@ REVOKE [ GRANT OPTION FOR ]
 
 REVOKE [ GRANT OPTION FOR ]
     { EXECUTE | ALL [ PRIVILEGES ] }
-    ON { FUNCTION <replaceable>function_name</replaceable> [ ( [ [ <replaceable class="parameter">argmode</replaceable> ] [ <replaceable class="parameter">arg_name</replaceable> ] <replaceable class="parameter">arg_type</replaceable> [, ...] ] ) ] [, ...]
-         | ALL FUNCTIONS IN SCHEMA <replaceable>schema_name</replaceable> [, ...] }
+    ON { { FUNCTION | PROCEDURE | ROUTINE } <replaceable>function_name</replaceable> [ ( [ [ <replaceable class="parameter">argmode</replaceable> ] [ <replaceable class="parameter">arg_name</replaceable> ] <replaceable class="parameter">arg_type</replaceable> [, ...] ] ) ] [, ...]
+         | ALL { FUNCTIONS | PROCEDURES | ROUTINES } IN SCHEMA <replaceable>schema_name</replaceable> [, ...] }
     FROM { [ GROUP ] <replaceable class="parameter">role_name</replaceable> | PUBLIC } [, ...]
     [ CASCADE | RESTRICT ]
 
@@ -220,7 +220,7 @@ REVOKE [ ADMIN OPTION FOR ]
 </synopsis>
  </refsynopsisdiv>
 
- <refsect1 id="SQL-REVOKE-description">
+ <refsect1 id="sql-revoke-description">
 <!--==========================orignal english content==========================
   <title>Description</title>
 ____________________________________________________________________________-->
@@ -341,7 +341,7 @@ ____________________________________________________________________________-->
   </para>
  </refsect1>
 
- <refsect1 id="SQL-REVOKE-notes">
+ <refsect1 id="sql-revoke-notes">
 <!--==========================orignal english content==========================
   <title>Notes</title>
 ____________________________________________________________________________-->
@@ -367,7 +367,7 @@ ____________________________________________________________________________-->
   <para>
    A user can only revoke privileges that were granted directly by
    that user.  If, for example, user A has granted a privilege with
-   grant option to user B, and user B has in turned granted it to user
+   grant option to user B, and user B has in turn granted it to user
    C, then user A cannot revoke the privilege directly from C.
    Instead, user A could revoke the grant option from user B and use
    the <literal>CASCADE</literal> option so that the privilege is
@@ -478,7 +478,7 @@ ____________________________________________________________________________-->
    </para>
  </refsect1>
 
- <refsect1 id="SQL-REVOKE-examples">
+ <refsect1 id="sql-revoke-examples">
 <!--==========================orignal english content==========================
   <title>Examples</title>
 ____________________________________________________________________________-->
@@ -542,7 +542,7 @@ REVOKE admins FROM joe;
 </programlisting></para>
  </refsect1>
 
- <refsect1 id="SQL-REVOKE-compatibility">
+ <refsect1 id="sql-revoke-compatibility">
 <!--==========================orignal english content==========================
   <title>Compatibility</title>
 ____________________________________________________________________________-->


### PR DESCRIPTION
row6
	<refentry id="sql-revoke">    ##根据Winmerge比较结果，将SQL-REVOK改为小写

row92，93
    ON { { FUNCTION | PROCEDURE | ROUTINE } <replaceable>function_name</replaceable> [ ( [ [ <replaceable class="parameter">argmode</replaceable> ] [ <replaceable class="parameter">arg_name</replaceable> ] <replaceable class="parameter">arg_type</replaceable> [, ...] ] ) ] [, ...]
         | ALL { FUNCTIONS | PROCEDURES | ROUTINES } IN SCHEMA <replaceable>schema_name</replaceable> [, ...] }  ##根据Winmerge比较结果，将92，93行替换为pg 11.2相应内容。

row 223
	 <refsect1 id="sql-revoke-description">  ##根据Winmerge比较结果，将SQL-REVOK改为小写

row 344
 	<refsect1 id="sql-revoke-notes">  ##根据Winmerge比较结果，将SQL-REVOK改为小写

row 370
	   grant option to user B, and user B has in turn granted it to user  ##根据Winmerge比较结果，将"user B has in turned granted" 改为"user B has in turn granted"

row 481
	 <refsect1 id="sql-revoke-examples">  ##根据Winmerge比较结果，将SQL-REVOK改为小写

row 545
	 <refsect1 id="sql-revoke-compatibility">  ##根据Winmerge比较结果，将SQL-REVOK改为小写