### PR TITLE
ref/refresh_materialized_view.sgml，ref/prepare_transaction.sgml ，ref/revoke.sgml翻译及内容完善

### DIFF
--- a/postgresql/doc/src/sgml/ref/create_publication.sgml
+++ b/postgresql/doc/src/sgml/ref/create_publication.sgml
@@ -3,7 +3,7 @@ doc/src/sgml/ref/create_publication.sgml
 PostgreSQL documentation
 -->
 
-<refentry id="SQL-CREATEPUBLICATION">
+<refentry id="sql-createpublication">
 <!--==========================orignal english content==========================
  <indexterm zone="sql-createpublication">
   <primary>CREATE PUBLICATION</primary>
@@ -122,10 +122,10 @@ ____________________________________________________________________________-->
 <!--==========================orignal english content==========================
      <para>
       Specifies a list of tables to add to the publication.  If
-      <literal>ONLY</> is specified before the table name, only
-      that table is added to the publication.  If <literal>ONLY</> is not
+      <literal>ONLY</literal> is specified before the table name, only
+      that table is added to the publication.  If <literal>ONLY</literal> is not
       specified, the table and all its descendant tables (if any) are added.
-      Optionally, <literal>*</> can be specified after the table name to
+      Optionally, <literal>*</literal> can be specified after the table name to
       explicitly indicate that descendant tables are included.
      </para>
 ____________________________________________________________________________-->
@@ -190,10 +190,11 @@ ____________________________________________________________________________-->
           This parameter determines which DML operations will be published by
           the new publication to the subscribers.  The value is
           comma-separated list of operations.  The allowed operations are
-          <literal>insert</literal>, <literal>update</literal>, and
-          <literal>delete</literal>.  The default is to publish all actions,
+          <literal>insert</literal>, <literal>update</literal>,
+          <literal>delete</literal>, and <literal>truncate</literal>.
+          The default is to publish all actions,		  
           and so the default value for this option is
-          <literal>'insert, update, delete'</literal>.
+          <literal>'insert, update, delete, truncate'</literal>.
          </para>
         </listitem>
        </varlistentry>
@@ -211,9 +212,9 @@ ____________________________________________________________________________-->
          <para>
           这个参数决定了哪些DML操作将由新的发布发布给订阅者。
 		  该值是用逗号分隔的操作列表。允许的操作是<literal>insert</literal>，
-		  <literal>update</literal>和<literal>delete</literal>。
+		  <literal>update</literal>，<literal>delete</literal>和<literal>truncate</literal>。
 		  默认是发布所有的动作，所以这个选项的默认值是
-		  <literal>'insert, update, delete'</literal>。
+		  <literal>'insert, update, delete, truncate'</literal>。
          </para>
         </listitem>
        </varlistentry>
@@ -257,7 +258,7 @@ ____________________________________________________________________________-->
 <!--==========================orignal english content==========================
   <para>
    To create a publication, the invoking user must have the
-   <literal>CREATE</> privilege for the current database.
+   <literal>CREATE</literal> privilege for the current database.
    (Of course, superusers bypass this check.)
   </para>
 ____________________________________________________________________________-->
@@ -282,7 +283,7 @@ ____________________________________________________________________________-->
   <para>
    The tables added to a publication that publishes <command>UPDATE</command>
    and/or <command>DELETE</command> operations must have
-   <literal>REPLICA IDENTITY</> defined.  Otherwise those operations will be
+   <literal>REPLICA IDENTITY</literal> defined.  Otherwise those operations will be
    disallowed on those tables.
   </para>
 ____________________________________________________________________________-->
@@ -294,7 +295,7 @@ ____________________________________________________________________________-->
 
 <!--==========================orignal english content==========================
   <para>
-   For an <command>INSERT ... ON CONFLICT</> command, the publication will
+   For an <command>INSERT ... ON CONFLICT</command> command, the publication will
    publish the operation that actually results from the command.  So depending
    of the outcome, it may be published as either <command>INSERT</command> or
    <command>UPDATE</command>, or it may not be published at all.
@@ -318,12 +319,11 @@ ____________________________________________________________________________-->
 
 <!--==========================orignal english content==========================
   <para>
-   <command>TRUNCATE</command> and <acronym>DDL</acronym> operations
-   are not published.
+   <acronym>DDL</acronym> operations are not published.
   </para>
 ____________________________________________________________________________-->
   <para>
-   不发布<command>TRUNCATE</command>和<acronym>DDL</acronym>操作。
+   不发布<acronym>DDL</acronym>操作。
   </para>
  </refsect1>
 
@@ -388,7 +388,7 @@ ____________________________________________________________________________-->
 
 <!--==========================orignal english content==========================
   <para>
-   <command>CREATE PUBLICATION</command> is a <productname>PostgreSQL</>
+   <command>CREATE PUBLICATION</command> is a <productname>PostgreSQL</productname>
    extension.
   </para>
 ____________________________________________________________________________-->

--- a/postgresql/doc/src/sgml/ref/create_table.sgml
+++ b/postgresql/doc/src/sgml/ref/create_table.sgml
@@ -3,7 +3,7 @@ doc/src/sgml/ref/create_table.sgml
 PostgreSQL documentation
 -->
 
-<refentry id="SQL-CREATETABLE">
+<refentry id="sql-createtable">
 <!--==========================orignal english content==========================
  <indexterm zone="sql-createtable">
   <primary>CREATE TABLE</primary>
@@ -47,7 +47,7 @@ CREATE [ [ GLOBAL | LOCAL ] { TEMPORARY | TEMP } | UNLOGGED ] TABLE [ IF NOT EXI
     [, ... ]
 ] )
 [ INHERITS ( <replaceable>parent_table</replaceable> [, ... ] ) ]
-[ PARTITION BY { RANGE | LIST } ( { <replaceable class="parameter">column_name</replaceable> | ( <replaceable class="parameter">expression</replaceable> ) } [ COLLATE <replaceable class="parameter">collation</replaceable> ] [ <replaceable class="parameter">opclass</replaceable> ] [, ... ] ) ]
+[ PARTITION BY { RANGE | LIST | HASH } ( { <replaceable class="parameter">column_name</replaceable> | ( <replaceable class="parameter">expression</replaceable> ) } [ COLLATE <replaceable class="parameter">collation</replaceable> ] [ <replaceable class="parameter">opclass</replaceable> ] [, ... ] ) ]
 [ WITH ( <replaceable class="parameter">storage_parameter</replaceable> [= <replaceable class="parameter">value</replaceable>] [, ... ] ) | WITH OIDS | WITHOUT OIDS ]
 [ ON COMMIT { PRESERVE ROWS | DELETE ROWS | DROP } ]
 [ TABLESPACE <replaceable class="parameter">tablespace_name</replaceable> ]
@@ -58,7 +58,7 @@ CREATE [ [ GLOBAL | LOCAL ] { TEMPORARY | TEMP } | UNLOGGED ] TABLE [ IF NOT EXI
     | <replaceable>table_constraint</replaceable> }
     [, ... ]
 ) ]
-[ PARTITION BY { RANGE | LIST } ( { <replaceable class="parameter">column_name</replaceable> | ( <replaceable class="parameter">expression</replaceable> ) } [ COLLATE <replaceable class="parameter">collation</replaceable> ] [ <replaceable class="parameter">opclass</replaceable> ] [, ... ] ) ]
+[ PARTITION BY { RANGE | LIST | HASH } ( { <replaceable class="parameter">column_name</replaceable> | ( <replaceable class="parameter">expression</replaceable> ) } [ COLLATE <replaceable class="parameter">collation</replaceable> ] [ <replaceable class="parameter">opclass</replaceable> ] [, ... ] ) ]
 [ WITH ( <replaceable class="parameter">storage_parameter</replaceable> [= <replaceable class="parameter">value</replaceable>] [, ... ] ) | WITH OIDS | WITHOUT OIDS ]
 [ ON COMMIT { PRESERVE ROWS | DELETE ROWS | DROP } ]
 [ TABLESPACE <replaceable class="parameter">tablespace_name</replaceable> ]
@@ -68,8 +68,8 @@ CREATE [ [ GLOBAL | LOCAL ] { TEMPORARY | TEMP } | UNLOGGED ] TABLE [ IF NOT EXI
   { <replaceable class="parameter">column_name</replaceable> [ WITH OPTIONS ] [ <replaceable class="parameter">column_constraint</replaceable> [ ... ] ]
     | <replaceable>table_constraint</replaceable> }
     [, ... ]
-) ] FOR VALUES <replaceable class="parameter">partition_bound_spec</replaceable>
-[ PARTITION BY { RANGE | LIST } ( { <replaceable class="parameter">column_name</replaceable> | ( <replaceable class="parameter">expression</replaceable> ) } [ COLLATE <replaceable class="parameter">collation</replaceable> ] [ <replaceable class="parameter">opclass</replaceable> ] [, ... ] ) ]
+) ] { FOR VALUES <replaceable class="parameter">partition_bound_spec</replaceable> | DEFAULT }
+[ PARTITION BY { RANGE | LIST | HASH } ( { <replaceable class="parameter">column_name</replaceable> | ( <replaceable class="parameter">expression</replaceable> ) } [ COLLATE <replaceable class="parameter">collation</replaceable> ] [ <replaceable class="parameter">opclass</replaceable> ] [, ... ] ) ]
 [ WITH ( <replaceable class="parameter">storage_parameter</replaceable> [= <replaceable class="parameter">value</replaceable>] [, ... ] ) | WITH OIDS | WITHOUT OIDS ]
 [ ON COMMIT { PRESERVE ROWS | DELETE ROWS | DROP } ]
 [ TABLESPACE <replaceable class="parameter">tablespace_name</replaceable> ]
@@ -101,16 +101,18 @@ CREATE [ [ GLOBAL | LOCAL ] { TEMPORARY | TEMP } | UNLOGGED ] TABLE [ IF NOT EXI
 
 <phrase>and <replaceable class="parameter">like_option</replaceable> is:</phrase>
 
-{ INCLUDING | EXCLUDING } { DEFAULTS | CONSTRAINTS | IDENTITY | INDEXES | STORAGE | COMMENTS | ALL }
+{ INCLUDING | EXCLUDING } { COMMENTS | CONSTRAINTS | DEFAULTS | IDENTITY | INDEXES | STATISTICS | STORAGE | ALL }
 
 <phrase>and <replaceable class="parameter">partition_bound_spec</replaceable> is:</phrase>
 
-IN ( { <replaceable class="parameter">numeric_literal</replaceable> | <replaceable class="parameter">string_literal</replaceable> | NULL } [, ...] ) |
-FROM ( { <replaceable class="parameter">numeric_literal</replaceable> | <replaceable class="parameter">string_literal</replaceable> | MINVALUE | MAXVALUE } [, ...] )
-  TO ( { <replaceable class="parameter">numeric_literal</replaceable> | <replaceable class="parameter">string_literal</replaceable> | MINVALUE | MAXVALUE } [, ...] )
+IN ( { <replaceable class="parameter">numeric_literal</replaceable> | <replaceable class="parameter">string_literal</replaceable> | TRUE | FALSE | NULL } [, ...] ) |
+FROM ( { <replaceable class="parameter">numeric_literal</replaceable> | <replaceable class="parameter">string_literal</replaceable> | TRUE | FALSE | MINVALUE | MAXVALUE } [, ...] )
+  TO ( { <replaceable class="parameter">numeric_literal</replaceable> | <replaceable class="parameter">string_literal</replaceable> | TRUE | FALSE | MINVALUE | MAXVALUE } [, ...] ) |
+WITH ( MODULUS <replaceable class="parameter">numeric_literal</replaceable>, REMAINDER <replaceable class="parameter">numeric_literal</replaceable> )
 
 <phrase><replaceable class="parameter">index_parameters</replaceable> in <literal>UNIQUE</literal>, <literal>PRIMARY KEY</literal>, and <literal>EXCLUDE</literal> constraints are:</phrase>
 
+[ INCLUDE ( <replaceable class="parameter">column_name</replaceable> [, ... ] ) ]
 [ WITH ( <replaceable class="parameter">storage_parameter</replaceable> [= <replaceable class="parameter">value</replaceable>] [, ... ] ) ]
 [ USING INDEX TABLESPACE <replaceable class="parameter">tablespace_name</replaceable> ]
 
@@ -127,7 +129,7 @@ CREATE [ [ GLOBAL | LOCAL ] { TEMPORARY | TEMP } | UNLOGGED ] TABLE [ IF NOT EXI
     [, ... ]
 ] )
 [ INHERITS ( <replaceable>parent_table</replaceable> [, ... ] ) ]
-[ PARTITION BY { RANGE | LIST } ( { <replaceable class="parameter">column_name</replaceable> | ( <replaceable class="parameter">expression</replaceable> ) } [ COLLATE <replaceable class="parameter">collation</replaceable> ] [ <replaceable class="parameter">opclass</replaceable> ] [, ... ] ) ]
+[ PARTITION BY { RANGE | LIST | HASH } ( { <replaceable class="parameter">column_name</replaceable> | ( <replaceable class="parameter">expression</replaceable> ) } [ COLLATE <replaceable class="parameter">collation</replaceable> ] [ <replaceable class="parameter">opclass</replaceable> ] [, ... ] ) ]
 [ WITH ( <replaceable class="parameter">storage_parameter</replaceable> [= <replaceable class="parameter">value</replaceable>] [, ... ] ) | WITH OIDS | WITHOUT OIDS ]
 [ ON COMMIT { PRESERVE ROWS | DELETE ROWS | DROP } ]
 [ TABLESPACE <replaceable class="parameter">tablespace_name</replaceable> ]
@@ -138,7 +140,7 @@ CREATE [ [ GLOBAL | LOCAL ] { TEMPORARY | TEMP } | UNLOGGED ] TABLE [ IF NOT EXI
     | <replaceable>table_constraint</replaceable> }
     [, ... ]
 ) ]
-[ PARTITION BY { RANGE | LIST } ( { <replaceable class="parameter">column_name</replaceable> | ( <replaceable class="parameter">expression</replaceable> ) } [ COLLATE <replaceable class="parameter">collation</replaceable> ] [ <replaceable class="parameter">opclass</replaceable> ] [, ... ] ) ]
+[ PARTITION BY { RANGE | LIST | HASH } ( { <replaceable class="parameter">column_name</replaceable> | ( <replaceable class="parameter">expression</replaceable> ) } [ COLLATE <replaceable class="parameter">collation</replaceable> ] [ <replaceable class="parameter">opclass</replaceable> ] [, ... ] ) ]
 [ WITH ( <replaceable class="parameter">storage_parameter</replaceable> [= <replaceable class="parameter">value</replaceable>] [, ... ] ) | WITH OIDS | WITHOUT OIDS ]
 [ ON COMMIT { PRESERVE ROWS | DELETE ROWS | DROP } ]
 [ TABLESPACE <replaceable class="parameter">tablespace_name</replaceable> ]
@@ -148,8 +150,8 @@ CREATE [ [ GLOBAL | LOCAL ] { TEMPORARY | TEMP } | UNLOGGED ] TABLE [ IF NOT EXI
   { <replaceable class="parameter">column_name</replaceable> [ WITH OPTIONS ] [ <replaceable class="parameter">column_constraint</replaceable> [ ... ] ]
     | <replaceable>table_constraint</replaceable> }
     [, ... ]
-) ] FOR VALUES <replaceable class="parameter">partition_bound_spec</replaceable>
-[ PARTITION BY { RANGE | LIST } ( { <replaceable class="parameter">column_name</replaceable> | ( <replaceable class="parameter">expression</replaceable> ) } [ COLLATE <replaceable class="parameter">collation</replaceable> ] [ <replaceable class="parameter">opclass</replaceable> ] [, ... ] ) ]
+) ] { FOR VALUES <replaceable class="parameter">partition_bound_spec</replaceable> | DEFAULT }
+[ PARTITION BY { RANGE | LIST | HASH } ( { <replaceable class="parameter">column_name</replaceable> | ( <replaceable class="parameter">expression</replaceable> ) } [ COLLATE <replaceable class="parameter">collation</replaceable> ] [ <replaceable class="parameter">opclass</replaceable> ] [, ... ] ) ]
 [ WITH ( <replaceable class="parameter">storage_parameter</replaceable> [= <replaceable class="parameter">value</replaceable>] [, ... ] ) | WITH OIDS | WITHOUT OIDS ]
 [ ON COMMIT { PRESERVE ROWS | DELETE ROWS | DROP } ]
 [ TABLESPACE <replaceable class="parameter">tablespace_name</replaceable> ]
@@ -181,16 +183,18 @@ CREATE [ [ GLOBAL | LOCAL ] { TEMPORARY | TEMP } | UNLOGGED ] TABLE [ IF NOT EXI
 
 <phrase><replaceable class="parameter">like_option</replaceable> 是：</phrase>
 
-{ INCLUDING | EXCLUDING } { DEFAULTS | CONSTRAINTS | IDENTITY | INDEXES | STORAGE | COMMENTS | ALL }
+{ INCLUDING | EXCLUDING } { COMMENTS | CONSTRAINTS | DEFAULTS | IDENTITY | INDEXES | STATISTICS | STORAGE | ALL }
 
 <phrase><replaceable class="parameter">partition_bound_spec</replaceable> 是:</phrase>
 
-IN ( { <replaceable class="parameter">numeric_literal</replaceable> | <replaceable class="parameter">string_literal</replaceable> | NULL } [, ...] ) |
-FROM ( { <replaceable class="parameter">numeric_literal</replaceable> | <replaceable class="parameter">string_literal</replaceable> | MINVALUE | MAXVALUE } [, ...] )
-  TO ( { <replaceable class="parameter">numeric_literal</replaceable> | <replaceable class="parameter">string_literal</replaceable> | MINVALUE | MAXVALUE } [, ...] )
+IN ( { <replaceable class="parameter">numeric_literal</replaceable> | <replaceable class="parameter">string_literal</replaceable> | TRUE | FALSE | NULL } [, ...] ) |
+FROM ( { <replaceable class="parameter">numeric_literal</replaceable> | <replaceable class="parameter">string_literal</replaceable> | TRUE | FALSE | MINVALUE | MAXVALUE } [, ...] )
+  TO ( { <replaceable class="parameter">numeric_literal</replaceable> | <replaceable class="parameter">string_literal</replaceable> | TRUE | FALSE | MINVALUE | MAXVALUE } [, ...] ) |
+WITH ( MODULUS <replaceable class="parameter">numeric_literal</replaceable>, REMAINDER <replaceable class="parameter">numeric_literal</replaceable> )
 
 <literal>UNIQUE</literal>、<literal>PRIMARY KEY</literal>以及<literal>EXCLUDE</literal>约束中的<phrase><replaceable class="parameter">index_parameters</replaceable>是：</phrase>
 
+[ INCLUDE ( <replaceable class="parameter">column_name</replaceable> [, ... ] ) ]
 [ WITH ( <replaceable class="parameter">storage_parameter</replaceable> [= <replaceable class="parameter">value</replaceable>] [, ... ] ) ]
 [ USING INDEX TABLESPACE <replaceable class="parameter">tablespace_name</replaceable> ]
 
@@ -201,7 +205,7 @@ FROM ( { <replaceable class="parameter">numeric_literal</replaceable> | <replace
 
  </refsynopsisdiv>
 
- <refsect1 id="SQL-CREATETABLE-description">
+ <refsect1 id="sql-createtable-description">
 <!--==========================orignal english content==========================
   <title>Description</title>
 ____________________________________________________________________________-->
@@ -292,7 +296,7 @@ ____________________________________________________________________________-->
 
   <variablelist>
 
-   <varlistentry id="SQL-CREATETABLE-TEMPORARY">
+   <varlistentry id="sql-createtable-temporary">
 <!--==========================orignal english content==========================
     <term><literal>TEMPORARY</> or <literal>TEMP</></term>
 ____________________________________________________________________________-->
@@ -344,7 +348,7 @@ ____________________________________________________________________________-->
     </listitem>
    </varlistentry>
 
-   <varlistentry id="SQL-CREATETABLE-UNLOGGED">
+   <varlistentry id="sql-createtable-unlogged">
 <!--==========================orignal english content==========================
     <term><literal>UNLOGGED</></term>
 ____________________________________________________________________________-->
@@ -438,20 +442,291 @@ ____________________________________________________________________________-->
      </para>
     </listitem>
    </varlistentry>
-   <varlistentry id="SQL-CREATETABLE-PARTITION">
+   
+   <varlistentry>
 <!--==========================orignal english content==========================
-    <term><literal>PARTITION OF <replaceable class="parameter">parent_table</replaceable> FOR VALUES <replaceable class="parameter">partition_bound_spec</replaceable></literal></term>
+    <term><replaceable class="parameter">column_name</replaceable></term>
 ____________________________________________________________________________-->
-    <term><literal>PARTITION OF <replaceable class="parameter">parent_table</replaceable> FOR VALUES <replaceable class="parameter">partition_bound_spec</replaceable></literal></term>
+    <term><replaceable class="parameter">column_name</replaceable></term>
     <listitem>
 <!--==========================orignal english content==========================
      <para>
+      The name of a column to be created in the new table.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      列的名称会在新表中被建立.
+     </para>	 
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+<!--==========================orignal english content==========================
+    <term><replaceable class="parameter">data_type</replaceable></term>
+____________________________________________________________________________-->
+    <term><replaceable class="parameter">data_type</replaceable></term>
+    <listitem>
+<!--==========================orignal english content==========================
+     <para>
+      The data type of the column. This can include array
+      specifiers. For more information on the data types supported by
+      <productname>PostgreSQL</productname>, refer to <xref
+      linkend="datatype"/>.
+     </para>
+____________________________________________________________________________-->	 
+     <para>
+      列的数据类型. 这可以包括数组
+      规格. 有关<productname>PostgreSQL</productname>支持数据类型的详细信息, 请参考<xref
+      linkend="datatype"/>.
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+<!--==========================orignal english content==========================
+    <term><literal>COLLATE <replaceable>collation</replaceable></literal></term>
+____________________________________________________________________________-->
+    <term><literal>COLLATE <replaceable>collation</replaceable></literal></term>
+    <listitem>
+<!--==========================orignal english content==========================
+     <para>
+      The <literal>COLLATE</literal> clause assigns a collation to
+      the column (which must be of a collatable data type).
+      If not specified, the column data type's default collation is used.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      <literal>COLLATE</literal>子句为该列（必须是一种可排序数据类型）赋予一个排序规则。
+      如果没有指定，将使用该列数据类型的默认排序规则。
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+<!--==========================orignal english content==========================
+    <term><literal>INHERITS ( <replaceable>parent_table</replaceable> [, ... ] )</literal></term>
+____________________________________________________________________________-->
+    <term><literal>INHERITS ( <replaceable>parent_table</replaceable> [, ... ] )</literal></term>
+    <listitem>
+<!--==========================orignal english content==========================
+     <para>
+      The optional <literal>INHERITS</literal> clause specifies a list of
+      tables from which the new table automatically inherits all
+      columns.  Parent tables can be plain tables or foreign tables.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      可选的<literal>INHERITS</literal>子句指定一个表的列表，
+	  新表将从其中自动地继承所有列。
+	  父表可以是普通表或者外部表。
+     </para>
+
+<!--==========================orignal english content==========================
+     <para>
+      Use of <literal>INHERITS</literal> creates a persistent relationship
+      between the new child table and its parent table(s).  Schema
+      modifications to the parent(s) normally propagate to children
+      as well, and by default the data of the child table is included in
+      scans of the parent(s).
+     </para>
+____________________________________________________________________________-->
+     <para>
+      <literal>INHERITS</literal>的使用在新的子表和它的父表之间创建一种持久的关系。
+	  对于父表的模式修改通常也会传播到子表，
+	  并且默认情况下子表的数据会被包括在对父表的扫描中。
+     </para>
+
+<!--==========================orignal english content==========================
+     <para>
+      If the same column name exists in more than one parent
+      table, an error is reported unless the data types of the columns
+      match in each of the parent tables.  If there is no conflict,
+      then the duplicate columns are merged to form a single column in
+      the new table.  If the column name list of the new table
+      contains a column name that is also inherited, the data type must
+      likewise match the inherited column(s), and the column
+      definitions are merged into one.  If the
+      new table explicitly specifies a default value for the column,
+      this default overrides any defaults from inherited declarations
+      of the column.  Otherwise, any parents that specify default
+      values for the column must all specify the same default, or an
+      error will be reported.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      如果在多个父表中存在同名的列，除非父表中每一个这种列的数据类型都能匹配，
+	  否则会报告一个错误。如果没有冲突，那么重复列会被融合来形成新表中的一个单一列。
+	  如果新表中的列名列表包含一个也是继承而来的列名，该数据类型必须也匹配继承的列，
+	  并且列定义会被融合成一个。如果新表显式地为列指定了任何默认值，
+	  这个默认值将覆盖来自该列继承声明中的默认值。
+	  否则，任何父表都必须为该列指定相同的默认值，或者会报告一个错误。
+     </para>
+
+<!--==========================orignal english content==========================
+     <para>
+      <literal>CHECK</literal> constraints are merged in essentially the same way as
+      columns: if multiple parent tables and/or the new table definition
+      contain identically-named <literal>CHECK</literal> constraints, these
+      constraints must all have the same check expression, or an error will be
+      reported.  Constraints having the same name and expression will
+      be merged into one copy.  A constraint marked <literal>NO INHERIT</literal> in a
+      parent will not be considered.  Notice that an unnamed <literal>CHECK</literal>
+      constraint in the new table will never be merged, since a unique name
+      will always be chosen for it.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      <literal>CHECK</literal>约束本质上也采用和列相同的方式被融合：
+	  如果多个父表或者新表定义中包含相同的命名<literal>CHECK</literal>约束，
+	  这些约束必须全部具有相同的检查表达式，否则将报告一个错误。
+	  具有相同名称和表达式的约束将被融合成一份拷贝。
+	  一个父表中的被标记为<literal>NO INHERIT</literal>的约束将不会被考虑。
+	  注意新表中一个未命名的<literal>CHECK</literal>约束将永远不会被融合，
+	  因为那样总是会为它选择一个唯一的名字。
+     </para>
+
+<!--==========================orignal english content==========================
+     <para>
+      Column <literal>STORAGE</literal> settings are also copied from parent tables.
+     </para>
+____________________________________________________________________________-->
+     <para>
+       列的<literal>STORAGE</literal>设置也会从父表复制过来。
+     </para>
+
+<!--==========================orignal english content==========================
+     <para>
+      If a column in the parent table is an identity column, that property is
+      not inherited.  A column in the child table can be declared identity
+      column if desired.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      如果父表中的列是标识列，那么该属性不会被继承。
+	  如果需要，可以将子表中的列声明为标识列。
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+<!--==========================orignal english content==========================
+    <term><literal>PARTITION BY { RANGE | LIST | HASH } ( { <replaceable class="parameter">column_name</replaceable> | ( <replaceable class="parameter">expression</replaceable> ) } [ <replaceable class="parameter">opclass</replaceable> ] [, ...] ) </literal></term>
+____________________________________________________________________________-->
+    <term><literal>PARTITION BY { RANGE | LIST | HASH } ( { <replaceable class="parameter">column_name</replaceable> | ( <replaceable class="parameter">expression</replaceable> ) } [ <replaceable class="parameter">opclass</replaceable> ] [, ...] ) </literal></term>
+    <listitem>
+<!--==========================orignal english content==========================
+     <para>
+      The optional <literal>PARTITION BY</literal> clause specifies a strategy
+      of partitioning the table.  The table thus created is called a
+      <firstterm>partitioned</firstterm> table.  The parenthesized list of
+      columns or expressions forms the <firstterm>partition key</firstterm>
+      for the table.  When using range or hash partitioning, the partition key
+      can include multiple columns or expressions (up to 32, but this limit can
+      be altered when building <productname>PostgreSQL</productname>), but for
+      list partitioning, the partition key must consist of a single column or
+      expression.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      可选的<literal>PARTITION BY</literal>子句指定了对表进行分区的策略。
+	  这样创建的表称为<firstterm>分区</firstterm>表。
+	  带括号的列或表达式的列表构成表的<firstterm>分区键</firstterm>。
+	  使用范围或哈希分区时，分区键可以包含多个列或表达式（最多32个，但在构建
+	  <productname>PostgreSQL</productname>时可以更改此限制），
+	  但对于列表分区，分区键必须由单个列或表达式组成。
+     </para>
+
+
+<!--==========================orignal english content==========================
+     <para>
+      Range and list partitioning require a btree operator class, while hash
+      partitioning requires a hash operator class.  If no operator class is
+      specified explicitly, the default operator class of the appropriate
+      type will be used; if no default operator class exists, an error will
+      be raised.  When hash partitioning is used, the operator class used
+      must implement support function 2 (see <xref linkend="xindex-support"/>
+      for details).
+     </para>
+____________________________________________________________________________-->
+     <para>
+      范围和列表分区需要 btree 运算符类，而哈希分区需要哈希运算符类。
+	  如果没有运算符类被显式指定，将使用相应类型的默认运算符类;
+	  如果不存在默认运算符类，则将引发错误。 
+	  使用哈希分区时，所使用的运算符类必须实现支持功能 2（详情请参阅<xref linkend="xindex-support"/>）。
+     </para>
+
+<!--==========================orignal english content==========================
+     <para>
+      A partitioned table is divided into sub-tables (called partitions),
+      which are created using separate <literal>CREATE TABLE</literal> commands.
+      The partitioned table is itself empty.  A data row inserted into the
+      table is routed to a partition based on the value of columns or
+      expressions in the partition key.  If no existing partition matches
+      the values in the new row, an error will be reported.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      分区表被分成多个子表（称为分区），它们是使用单独的<literal>CREATE TABLE</literal>命令创建的。
+	  分区表本身是空的。插入到表中的数据行将根据分区键中的列或表达式的值路由到分区。
+	  如果没有现有的分区与新行中的值匹配，则会报告错误。
+     </para>
+
+<!--==========================orignal english content==========================
+     <para>
+      Partitioned tables do not support <literal>EXCLUDE</literal> constraints;
+      however, you can define these constraints on individual partitions.
+      Also, while it's possible to define <literal>PRIMARY KEY</literal>
+      constraints on partitioned tables, creating foreign keys that
+      reference a partitioned table is not yet supported.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      Partitioned tables do not support <literal>EXCLUDE</literal> constraints;
+      however, you can define these constraints on individual partitions.
+      Also, while it's possible to define <literal>PRIMARY KEY</literal>
+      constraints on partitioned tables, creating foreign keys that
+      reference a partitioned table is not yet supported.
+	  分区表不支持<literal>EXCLUDE</literal>约束；
+	  但是，你可以在各个分区上定义这些约束。
+	  此外，虽然可以在分区表上定义<literal>PRIMARY KEY</literal>约束，
+	  但引用分区表来创建外键还不能支持。
+     </para>
+	 
+<!--==========================orignal english content==========================	 
+     <para>
+      See <xref linkend="ddl-partitioning"/> for more discussion on table
+      partitioning.
+     </para>
+____________________________________________________________________________-->
+     <para>
+	  有关表分区的更多讨论，请参阅<xref linkend="ddl-partitioning"/>
+     </para>
+
+    </listitem>
+   </varlistentry>
+
+   <varlistentry id="sql-createtable-partition">
+<!--==========================orignal english content==========================	 
+    <term><literal>PARTITION OF <replaceable class="parameter">parent_table</replaceable> { FOR VALUES <replaceable class="parameter">partition_bound_spec</replaceable> | DEFAULT }</literal></term>
+____________________________________________________________________________-->
+    <term><literal>PARTITION OF <replaceable class="parameter">parent_table</replaceable> { FOR VALUES <replaceable class="parameter">partition_bound_spec</replaceable> | DEFAULT }</literal></term>
+
+    <listitem>
+	
+<!--==========================orignal english content==========================
+     <para>
       Creates the table as a <firstterm>partition</firstterm> of the specified
-      parent table.
+      parent table. The table can be created either as a partition for specific
+      values using <literal>FOR VALUES</literal> or as a default partition
+      using <literal>DEFAULT</literal>.  This option is not available for
+      hash-partitioned tables.
      </para>
 ____________________________________________________________________________-->
      <para>
       将表创建为指定父表的<firstterm>分区</firstterm>。
+	  该表建立时，可以使用<literal>FOR VALUES</literal>创建为特定值的分区，
+	  也可以使用<literal>DEFAULT</literal>创建默认分区。
+	  此选项不适用于哈希分区表。
      </para>
 
 <!--==========================orignal english content==========================
@@ -459,15 +734,18 @@ ____________________________________________________________________________-->
       The <replaceable class="parameter">partition_bound_spec</replaceable>
       must correspond to the partitioning method and partition key of the
       parent table, and must not overlap with any existing partition of that
-      parent.  The form with <literal>IN</> is used for list partitioning,
-      while the form with <literal>FROM</> and <literal>TO</> is used for
-      range partitioning.
+      parent.  The form with <literal>IN</literal> is used for list partitioning,
+      the form with <literal>FROM</literal> and <literal>TO</literal> is used
+	  for range partitioning, and the form with <literal>WITH</literal> is used
+	  for hash partitioning.
      </para>
 ____________________________________________________________________________-->
      <para>
       <replaceable class="parameter">partition_bound_spec</replaceable>
 	  必须对应于父表的分区方法和分区键，并且必须不能与该父表的任何现有分区重叠。
-	  形式用于列表分区，<literal>FROM</literal>和<literal>TO</literal>形式用于范围分区。
+	  具有<literal>IN</literal>的形式用于列表分区，
+	  具有<literal>FROM</literal>和<literal>TO</literal>的形式用于范围分区，
+	  具有<literal>WITH</literal>的形式用于哈希分区。
      </para>
 
 <!--==========================orignal english content==========================
@@ -610,6 +888,78 @@ ____________________________________________________________________________-->
 
 <!--==========================orignal english content==========================
      <para>
+      If <literal>DEFAULT</literal> is specified, the table will be
+      created as a default partition of the parent table. The parent can
+      either be a list or range partitioned table. A partition key value
+      not fitting into any other partition of the given parent will be
+      routed to the default partition. There can be only one default
+      partition for a given parent table.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      如果指定了<literal>DEFAULT</literal>，则表将创建为父表的默认分区。
+	  父级表可以是列表或范围分区表。
+	  不适合给定父级表的任何其他分区的分区键值将路由到默认分区。
+	  给定父级表只能有一个默认分区。
+     </para>
+
+<!--==========================orignal english content==========================
+     <para>
+      When a table has an existing <literal>DEFAULT</literal> partition and
+      a new partition is added to it, the existing default partition must
+      be scanned to verify that it does not contain any rows which properly
+      belong in the new partition.  If the default partition contains a
+      large number of rows, this may be slow.  The scan will be skipped if
+      the default partition is a foreign table or if it has a constraint which
+      proves that it cannot contain rows which should be placed in the new
+      partition.
+     </para>
+____________________________________________________________________________-->
+     <para>
+	  当一个表已有<literal>DEFAULT</literal> 分区并且要对它添加新分区时，
+	  必须扫描现有的默认分区以验证它不包含可能属于新分区的任何行。 
+	  如果默认分区包含大量行，则速度可能会很慢。
+	  如果默认分区是外表或者它具有可证明的不可能包含能放置在新分区中的行的约束，则将略过扫描	  
+     </para>
+
+<!--==========================orignal english content==========================
+     <para>
+      When creating a hash partition, a modulus and remainder must be specified.
+      The modulus must be a positive integer, and the remainder must be a
+      non-negative integer less than the modulus.  Typically, when initially
+      setting up a hash-partitioned table, you should choose a modulus equal to
+      the number of partitions and assign every table the same modulus and a
+      different remainder (see examples, below).   However, it is not required
+      that every partition have the same modulus, only that every modulus which
+      occurs among the partitions of a hash-partitioned table is a factor of the
+      next larger modulus.  This allows the number of partitions to be increased
+      incrementally without needing to move all the data at once.  For example,
+      suppose you have a hash-partitioned table with 8 partitions, each of which
+      has modulus 8, but find it necessary to increase the number of partitions
+      to 16.  You can detach one of the modulus-8 partitions, create two new
+      modulus-16 partitions covering the same portion of the key space (one with
+      a remainder equal to the remainder of the detached partition, and the
+      other with a remainder equal to that value plus 8), and repopulate them
+      with data.  You can then repeat this -- perhaps at a later time -- for
+      each modulus-8 partition until none remain.  While this may still involve
+      a large amount of data movement at each step, it is still better than
+      having to create a whole new table and move all the data at once.
+     </para>
+____________________________________________________________________________-->	 
+     <para>
+      当创建哈希分区时，必须指定模数和余数。
+	  模数必须是正整数，余数必须是小于模数的非负整数。
+	  通常情况下，当初始设置哈希分区表时，应选择一个与分区数相等的模数，并为每个表分配相同的模数和不同的余数（请参阅下方示例）。
+	  不过，并不要求每个分区都具有相同的模数，只要求哈希分区表里面的分区中出现的每个模数都是下一个较大模数的因数。
+	  这允许以增量的方式增加分区数量而不需要一次移动所有数据。
+	  例如，假设你有一个包含 8 个分区的哈希分区表，每个分区有模数8，但发现有必要将分区数增加到 16 个。
+	  您可以拆分其中一个模数-8分区，然后创建两个新的模数-16分区来覆盖键空间的相同部分（一个的余数等于被拆分的分区的余数，另一个的余数等于该值加 8），而后用数据重新填充他们。
+	  然后，你可以对每一个余数-8分区重复此操作过程，直到没有剩余。
+	  虽然这其中的每个步骤都可能会导致大量的数据移动操作，它仍然要好于建一个全新的表并一次移动全部数据。
+     </para>	 
+	 
+<!--==========================orignal english content==========================
+     <para>
       A partition must have the same column names and types as the partitioned
       table to which it belongs.  If the parent is specified <literal>WITH
       OIDS</literal> then all partitions must have OIDs; the parent's OID
@@ -637,14 +987,11 @@ ____________________________________________________________________________-->
      <para>
       Rows inserted into a partitioned table will be automatically routed to
       the correct partition.  If no suitable partition exists, an error will
-      occur.  Also, if updating a row in a given partition would require it
-      to move to another partition due to new partition key values, an error
-      will occur.
+      occur. 
      </para>
 ____________________________________________________________________________-->
      <para>
       插入分区表中的行将自动路由到正确的分区。如果不存在合适的分区，则会发生错误。
-	  另外，如果更新给定分区中的行由于新的分区键值而要求它移动到另一分区，则会发生错误。
      </para>
 
 <!--==========================orignal english content==========================
@@ -678,199 +1025,6 @@ ____________________________________________________________________________-->
      <para>
       要在新表中创建的一列的名称。
      </para>
-    </listitem>
-   </varlistentry>
-
-   <varlistentry>
-<!--==========================orignal english content==========================
-    <term><replaceable class="parameter">data_type</replaceable></term>
-____________________________________________________________________________-->
-    <term><replaceable class="parameter">data_type</replaceable></term>
-    <listitem>
-<!--==========================orignal english content==========================
-     <para>
-      The data type of the column. This can include array
-      specifiers. For more information on the data types supported by
-      <productname>PostgreSQL</productname>, refer to <xref
-      linkend="datatype">.
-     </para>
-____________________________________________________________________________-->
-     <para>
-      该列的数据类型。这可以包括数组说明符。更多关于<productname>PostgreSQL</productname>支持的数据类型，请参考<xref linkend="datatype"/>。
-     </para>
-    </listitem>
-   </varlistentry>
-
-   <varlistentry>
-<!--==========================orignal english content==========================
-    <term><literal>COLLATE <replaceable>collation</replaceable></literal></term>
-____________________________________________________________________________-->
-    <term><literal>COLLATE <replaceable>collation</replaceable></literal></term>
-    <listitem>
-<!--==========================orignal english content==========================
-     <para>
-      The <literal>COLLATE</> clause assigns a collation to
-      the column (which must be of a collatable data type).
-      If not specified, the column data type's default collation is used.
-     </para>
-____________________________________________________________________________-->
-     <para>
-      <literal>COLLATE</literal>子句为该列（必须是一种可排序数据类型）赋予一个排序规则。如果没有指定，将使用该列数据类型的默认排序规则。
-     </para>
-    </listitem>
-   </varlistentry>
-
-   <varlistentry>
-<!--==========================orignal english content==========================
-    <term><literal>INHERITS ( <replaceable>parent_table</replaceable> [, ... ] )</literal></term>
-____________________________________________________________________________-->
-    <term><literal>INHERITS ( <replaceable>parent_table</replaceable> [, ... ] )</literal></term>
-    <listitem>
-<!--==========================orignal english content==========================
-     <para>
-      The optional <literal>INHERITS</> clause specifies a list of
-      tables from which the new table automatically inherits all
-      columns.  Parent tables can be plain tables or foreign tables.
-     </para>
-____________________________________________________________________________-->
-     <para>
-      可选的<literal>INHERITS</literal>子句指定一个表的列表，新表将从其中自动地继承所有列。父表可以是普通表或者外部表。
-     </para>
-
-<!--==========================orignal english content==========================
-     <para>
-      Use of <literal>INHERITS</> creates a persistent relationship
-      between the new child table and its parent table(s).  Schema
-      modifications to the parent(s) normally propagate to children
-      as well, and by default the data of the child table is included in
-      scans of the parent(s).
-     </para>
-____________________________________________________________________________-->
-     <para>
-      <literal>INHERITS</literal>的使用在新的子表和它的父表之间创建一种持久的关系。对于父表的模式修改通常也会传播到子表，并且默认情况下子表的数据会被包括在对父表的扫描中。
-     </para>
-
-<!--==========================orignal english content==========================
-     <para>
-      If the same column name exists in more than one parent
-      table, an error is reported unless the data types of the columns
-      match in each of the parent tables.  If there is no conflict,
-      then the duplicate columns are merged to form a single column in
-      the new table.  If the column name list of the new table
-      contains a column name that is also inherited, the data type must
-      likewise match the inherited column(s), and the column
-      definitions are merged into one.  If the
-      new table explicitly specifies a default value for the column,
-      this default overrides any defaults from inherited declarations
-      of the column.  Otherwise, any parents that specify default
-      values for the column must all specify the same default, or an
-      error will be reported.
-     </para>
-____________________________________________________________________________-->
-     <para>
-      如果在多个父表中存在同名的列，除非父表中每一个这种列的数据类型都能匹配，否则会报告一个错误。如果没有冲突，那么重复列会被融合来形成新表中的一个单一列。如果新表中的列名列表包含一个也是继承而来的列名，该数据类型必须也匹配继承的列，并且列定义会被融合成一个。如果新表显式地为列指定了任何默认值，这个默认值将覆盖来自该列继承声明中的默认值。否则，任何父表都必须为该列指定相同的默认值，或者会报告一个错误。
-     </para>
-
-<!--==========================orignal english content==========================
-     <para>
-      <literal>CHECK</> constraints are merged in essentially the same way as
-      columns: if multiple parent tables and/or the new table definition
-      contain identically-named <literal>CHECK</> constraints, these
-      constraints must all have the same check expression, or an error will be
-      reported.  Constraints having the same name and expression will
-      be merged into one copy.  A constraint marked <literal>NO INHERIT</> in a
-      parent will not be considered.  Notice that an unnamed <literal>CHECK</>
-      constraint in the new table will never be merged, since a unique name
-      will always be chosen for it.
-     </para>
-____________________________________________________________________________-->
-     <para>
-      <literal>CHECK</literal>约束本质上也采用和列相同的方式被融合：如果多个父表或者新表定义中包含相同的命名<literal>CHECK</literal>约束，这些约束必须全部具有相同的检查表达式，否则将报告一个错误。具有相同名称和表达式的约束将被融合成一份拷贝。一个父表中的被标记为<literal>NO INHERIT</literal>的约束将不会被考虑。注意新表中一个未命名的<literal>CHECK</literal>约束将永远不会被融合，因为那样总是会为它选择一个唯一的名字。
-     </para>
-
-<!--==========================orignal english content==========================
-     <para>
-      Column <literal>STORAGE</> settings are also copied from parent tables.
-     </para>
-____________________________________________________________________________-->
-     <para>
-      列的<literal>STORAGE</literal>设置也会从父表复制过来。
-     </para>
-<!--==========================orignal english content==========================
-     <para>
-      If a column in the parent table is an identity column, that property is
-      not inherited.  A column in the child table can be declared identity
-      column if desired.
-     </para>
-____________________________________________________________________________-->
-     <para>
-      如果父表中的列是标识列，那么该属性不会被继承。如果需要，
-	  可以将子表中的列声明为标识列。
-     </para>
-    </listitem>
-   </varlistentry>
-
-   <varlistentry>
-<!--==========================orignal english content==========================
-    <term><literal>PARTITION BY { RANGE | LIST } ( { <replaceable class="parameter">column_name</replaceable> | ( <replaceable class="parameter">expression</replaceable> ) } [ <replaceable class="parameter">opclass</replaceable> ] [, ...] ) </literal></term>
-____________________________________________________________________________-->
-    <term><literal>PARTITION BY { RANGE | LIST } ( { <replaceable class="parameter">column_name</replaceable> | ( <replaceable class="parameter">expression</replaceable> ) } [ <replaceable class="parameter">opclass</replaceable> ] [, ...] ) </literal></term>
-    <listitem>
-<!--==========================orignal english content==========================
-     <para>
-      The optional <literal>PARTITION BY</literal> clause specifies a strategy
-      of partitioning the table.  The table thus created is called a
-      <firstterm>partitioned</firstterm> table.  The parenthesized list of
-      columns or expressions forms the <firstterm>partition key</firstterm>
-      for the table.  When using range partitioning, the partition key can
-      include multiple columns or expressions (up to 32, but this limit can be
-      altered when building <productname>PostgreSQL</productname>), but for
-      list partitioning, the partition key must consist of a single column or
-      expression.  If no B-tree operator class is specified when creating a
-      partitioned table, the default B-tree operator class for the datatype will
-      be used.  If there is none, an error will be reported.
-     </para>
-____________________________________________________________________________-->
-     <para>
-      可选的<literal>PARTITION BY</literal>子句指定了对表进行分区的策略。
-	  这样创建的表称为<firstterm>分区</firstterm>表。
-	  带括号的列或表达式列表形成表的<firstterm>分区键</firstterm>。
-	  使用范围分区时，分区键可以包含多个列或表达式（最多32个，但在构建
-	  <productname>PostgreSQL</productname>时可以更改此限制），但对于列表分区，
-	  分区键必须由单个列或表达式组成。如果在创建分区表时未指定B树操作符类，
-	  则将使用该数据类型的默认B树操作符类。如果没有，则会报告错误。
-     </para>
-
-<!--==========================orignal english content==========================
-     <para>
-      A partitioned table is divided into sub-tables (called partitions),
-      which are created using separate <literal>CREATE TABLE</> commands.
-      The partitioned table is itself empty.  A data row inserted into the
-      table is routed to a partition based on the value of columns or
-      expressions in the partition key.  If no existing partition matches
-      the values in the new row, an error will be reported.
-     </para>
-____________________________________________________________________________-->
-     <para>
-      分区表被分成多个子表（称为分区），它们是使用单独的<literal>CREATE TABLE</literal>命令创建的。
-	  分区表本身是空的。插入到表中的数据行将根据分区键中的列或表达式的值路由到分区。
-	  如果没有现有的分区与新行中的值匹配，则会报告错误。
-     </para>
-
-<!--==========================orignal english content==========================
-     <para>
-      Partitioned tables do not support <literal>UNIQUE</literal>,
-      <literal>PRIMARY KEY</literal>, <literal>EXCLUDE</literal>, or
-      <literal>FOREIGN KEY</literal> constraints; however, you can define
-      these constraints on individual partitions.
-     </para>
-____________________________________________________________________________-->
-     <para>
-      分区表不支持<literal>UNIQUE</literal>、
-      <literal>PRIMARY KEY</literal>、<literal>EXCLUDE</literal>或
-      <literal>FOREIGN KEY</literal>约束；不过，可以在单个分区中定义这些约束。
-     </para>
-
     </listitem>
    </varlistentry>
 
@@ -940,6 +1094,19 @@ ____________________________________________________________________________-->
      <para>
       非空约束总是会被复制到新表。<literal>CHECK</literal>约束只有在<literal>INCLUDING CONSTRAINTS</literal>被指定时才会被复制。列约束和表约束之间没有区别对待。
      </para>
+
+<!--==========================orignal english content==========================
+     <para>
+      Extended statistics are copied to the new table if
+      <literal>INCLUDING STATISTICS</literal> is specified.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      Extended statistics are copied to the new table if
+      <literal>INCLUDING STATISTICS</literal> is specified.
+	  如果指定了<literal>INCLUDING STATISTICS</literal>，那么扩展统计会被复制到新表。
+     </para>
+
 <!--==========================orignal english content==========================
      <para>
       Indexes, <literal>PRIMARY KEY</>, <literal>UNIQUE</>,
@@ -980,11 +1147,11 @@ ____________________________________________________________________________-->
 <!--==========================orignal english content==========================
      <para>
       <literal>INCLUDING ALL</literal> is an abbreviated form of
-      <literal>INCLUDING DEFAULTS INCLUDING IDENTITY INCLUDING CONSTRAINTS INCLUDING INDEXES INCLUDING STORAGE INCLUDING COMMENTS</literal>.
+      <literal>INCLUDING COMMENTS INCLUDING CONSTRAINTS INCLUDING DEFAULTS INCLUDING IDENTITY INCLUDING INDEXES INCLUDING STATISTICS INCLUDING STORAGE</literal>.
      </para>
 ____________________________________________________________________________-->
      <para><literal>INCLUDING ALL</literal>是
-      <literal>INCLUDING DEFAULTS INCLUDING IDENTITY INCLUDING CONSTRAINTS INCLUDING INDEXES INCLUDING STORAGE INCLUDING COMMENTS</literal>的简写形式。
+     <literal>INCLUDING COMMENTS INCLUDING CONSTRAINTS INCLUDING DEFAULTS INCLUDING IDENTITY INCLUDING INDEXES INCLUDING STATISTICS INCLUDING STORAGE</literal>.的简写形式。
      </para>
 <!--==========================orignal english content==========================
      <para>
@@ -1236,9 +1403,11 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
     <term><literal>UNIQUE</literal> （列约束）</term>
 <!--==========================orignal english content==========================
-    <term><literal>UNIQUE ( <replaceable class="parameter">column_name</replaceable> [, ... ] )</> (table constraint)</term>
+    <term><literal>UNIQUE ( <replaceable class="parameter">column_name</replaceable> [, ... ] )</literal>
+    <optional> INCLUDE ( <replaceable class="parameter">column_name</replaceable> [, ...]) </optional> (table constraint)</term>
 ____________________________________________________________________________-->
-    <term><literal>UNIQUE ( <replaceable class="parameter">column_name</replaceable> [, ... ] )</literal> （表约束）</term>
+    <term><literal>UNIQUE ( <replaceable class="parameter">column_name</replaceable> [, ... ] )</literal>
+    <optional> INCLUDE ( <replaceable class="parameter">column_name</replaceable> [, ...]) </optional> (表约束)</term>
 
     <listitem>
 <!--==========================orignal english content==========================
@@ -1275,6 +1444,44 @@ ____________________________________________________________________________-->
      <para>
       每一个唯一表约束必须命名一个列的集合，并且它与该表上任何其他唯一或主键约束所命名的列集合都不相同（否则它将是一个被列举了两次的约束）。
      </para>
+	 
+<!--==========================orignal english content==========================	 
+     <para>
+      When establishing a unique constraint for a multi-level partition
+      hierarchy, all the columns in the partition key of the target
+      partitioned table, as well as those of all its descendant partitioned
+      tables, must be included in the constraint definition.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      When establishing a unique constraint for a multi-level partition
+      hierarchy,all the columns in the partition key of the target
+      partitioned table, as well as those of all its descendant partitioned
+      tables, must be included in the constraint definition.
+	  在为多级分区层次结构建立唯一约束时，
+	  目标分区表的分区键中的所有列，以及那些由它派生的所有分区表，
+	  必须被包含在约束定义中。
+     </para>
+
+<!--==========================orignal english content==========================	 
+     <para>
+      Adding a unique constraint will automatically create a unique btree
+      index on the column or group of columns used in the constraint.
+      The optional clause <literal>INCLUDE</literal> adds to that index
+      one or more columns on which the uniqueness is not enforced.
+      Note that although the constraint is not enforced on the included columns,
+      it still depends on them.  Consequently, some operations on these columns
+      (e.g. <literal>DROP COLUMN</literal>) can cause cascaded constraint and
+      index deletion.
+     </para>
+____________________________________________________________________________-->	 
+     <para>
+	  添加唯一约束将自动在使用于约束的列或列组上创建唯一的 btree索引。
+	  可选子句 <literal>INCLUDE</literal>在不强制唯一性的情况下向该索引添加一个或多个列。
+	  请注意虽然约束在包含的列上是非强制的，但是它仍然依赖于它们。
+	  因此，这些列上的某些操作（例如<literal>DROP COLUMN</literal>）可能会导致级联约束和索引删除。
+     </para>	 
+
     </listitem>
    </varlistentry>
 
@@ -1284,9 +1491,11 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
     <term><literal>PRIMARY KEY</literal> （列约束）</term>
 <!--==========================orignal english content==========================
-    <term><literal>PRIMARY KEY ( <replaceable class="parameter">column_name</replaceable> [, ... ] )</> (table constraint)</term>
+    <term><literal>PRIMARY KEY ( <replaceable class="parameter">column_name</replaceable> [, ... ] )</literal>
+    <optional> INCLUDE ( <replaceable class="parameter">column_name</replaceable> [, ...]) </optional> (table constraint)</term>
 ____________________________________________________________________________-->
-    <term><literal>PRIMARY KEY ( <replaceable class="parameter">column_name</replaceable> [, ... ] )</literal> （表约束）</term>
+    <term><literal>PRIMARY KEY ( <replaceable class="parameter">column_name</replaceable> [, ... ] )</literal>
+    <optional> INCLUDE ( <replaceable class="parameter">column_name</replaceable> [, ...]) </optional> (表约束)</term>
     <listitem>
 <!--==========================orignal english content==========================
      <para>
@@ -1322,12 +1531,43 @@ ____________________________________________________________________________-->
      </para>
 ____________________________________________________________________________-->
      <para>
-      <literal>PRIMARY KEY</literal>强制的数据约束可以看成是<literal>UNIQUE</literal>和<literal>NOT NULL</literal>的组合，不过把一组列标识为主键也为模式设计提供了元数据，因为主键标识其他表可以依赖这一个列集合作为行的唯一标识符。
+      <literal>PRIMARY KEY</literal>强制的数据约束可以看成是<literal>UNIQUE</literal>和<literal>NOT NULL</literal>的组合，
+	  不过把一组列标识为主键也为模式设计提供了元数据，因为主键标识其他表可以依赖这一个列集合作为行的唯一标识符。
      </para>
+
+<!--==========================orignal english content==========================
+     <para>
+      <literal>PRIMARY KEY</literal> constraints share the restrictions that
+      <literal>UNIQUE</literal> constraints have when placed on partitioned
+      tables.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      <literal>PRIMARY KEY</literal> 约束共享<literal>UNIQUE</literal> 约束放到分区表上时限制。
+     </para>
+
+<!--==========================orignal english content==========================
+     <para>
+      Adding a <literal>PRIMARY KEY</literal> constraint will automatically
+      create a unique btree index on the column or group of columns used in the
+      constraint.  The optional <literal>INCLUDE</literal> clause allows a list
+      of columns to be specified which will be included in the non-key portion
+      of the index.  Although uniqueness is not enforced on the included columns,
+      the constraint still depends on them. Consequently, some operations on the
+      included columns (e.g. <literal>DROP COLUMN</literal>) can cause cascaded
+      constraint and index deletion.
+     </para>
+____________________________________________________________________________-->
+     <para>
+	  添加<literal>PRIMARY KEY</literal>约束将自动在用于约束的列或列组上创建唯一的 btree 索引。
+	  可选的<literal>INCLUDE</literal> 子句允许指定将被包含在索引的非-键部分中的列的列表。 
+	  虽然包含的列的唯一性是非强制的，但约束仍依赖于它们。
+	  因此，这些包含的列上的某些操作（例如<literal>DROP COLUMN</literal>）可能会导致级联约束和索引删除。
+     </para>	 	 
     </listitem>
    </varlistentry>
 
-   <varlistentry id="SQL-CREATETABLE-EXCLUDE">
+   <varlistentry id="sql-createtable-exclude">
 <!--==========================orignal english content==========================
     <term><literal>EXCLUDE [ USING <replaceable class="parameter">index_method</replaceable> ] ( <replaceable class="parameter">exclude_element</replaceable> WITH <replaceable class="parameter">operator</replaceable> [, ... ] ) <replaceable class="parameter">index_parameters</replaceable> [ WHERE ( <replaceable class="parameter">predicate</replaceable> ) ]</literal></term>
 ____________________________________________________________________________-->
@@ -1433,15 +1673,23 @@ ____________________________________________________________________________-->
       is used.  The referenced columns must be the columns of a non-deferrable
       unique or primary key constraint in the referenced table.  The user
       must have <literal>REFERENCES</> permission on the referenced table
-      (either the whole table, or the specific referenced columns).
+	  (either the whole table, or the specific referenced columns).  The
+      addition of a foreign key constraint requires a
+      <literal>SHARE ROW EXCLUSIVE</literal> lock on the referenced table.
       Note that foreign key constraints cannot be defined between temporary
-      tables and permanent tables.
+	  tables and permanent tables.  Also note that while it is possible to
+      define a foreign key on a partitioned table, it is not possible to
+      declare a foreign key that references a partitioned table.
      </para>
 ____________________________________________________________________________-->
      <para>
-      这些子句指定一个外键约束，它要求新表的一列或一个列的组必须只包含能匹配被引用表的某个行在被引用列上的值。如果<replaceable class="parameter">refcolumn</replaceable>列表被忽略，将使用<replaceable class="parameter">reftable</replaceable>的主键。被引用列必须是被引用表中一个非可延迟唯一约束或主键约束的列。
-	  用户必须在被引用的表（或整个表或特定的引用列）上拥有<literal>REFERENCES</literal>权限。
+      这些子句指定一个外键约束，它要求新表的一列或一个列的组必须只包含能匹配被引用表的某个行在被引用列上的值。
+	  如果<replaceable class="parameter">refcolumn</replaceable>列表被忽略，将使用<replaceable class="parameter">reftable</replaceable>的主键。
+	  被引用列必须是被引用表中一个非可延迟唯一约束或主键约束的列。
+	  用户必须在被引用的表（或整个表,或特定的引用列）上拥有<literal>REFERENCES</literal>权限。
+	  增加的外键约束需要<literal>SHARE ROW EXCLUSIVE</literal> 锁定引用的表。
 	  注意外键约束不能在临时表和永久表之间定义。
+	  此外请注意，虽然可以在分区表上定义外键，但不能够声明引用分区表的外键。
      </para>
 
 <!--==========================orignal english content==========================
@@ -1463,7 +1711,11 @@ ____________________________________________________________________________-->
      </para>
 ____________________________________________________________________________-->
      <para>
-      被插入到引用列的一个值会使用给定的匹配类型与被引用表的值进行匹配。有三种匹配类型：<literal>MATCH FULL</literal>、<literal>MATCH PARTIAL</literal>以及<literal>MATCH SIMPLE</literal>（这是默认值）。  <literal>MATCH FULL</literal>将不允许一个多列外键中的一列为空，除非所有外键列都是空；如果它们都是空，则不要求该行在被引用表中有一个匹配。<literal>MATCH SIMPLE</literal>允许任意外键列为空，如果任一为空，则不要求该行在被引用表中有一个匹配。<literal>MATCH PARTIAL</literal>现在还没有被实现（当然，<literal>NOT NULL</literal>约束能被应用在引用列上来组织这些情况发生）。
+      被插入到引用列的一个值会使用给定的匹配类型与被引用表的值进行匹配。
+	  有三种匹配类型：<literal>MATCH FULL</literal>、<literal>MATCH PARTIAL</literal>以及<literal>MATCH SIMPLE</literal>（这是默认值）。  
+	  <literal>MATCH FULL</literal>将不允许一个多列外键中的一列为空，除非所有外键列都是空；如果它们都是空，则不要求该行在被引用表中有一个匹配。
+	  <literal>MATCH SIMPLE</literal>允许任意外键列为空，如果任一为空，则不要求该行在被引用表中有一个匹配。
+	  <literal>MATCH PARTIAL</literal>现在还没有被实现（当然，<literal>NOT NULL</literal>约束能被应用在引用列上来组织这些情况发生）。
      </para>
 
 <!--==========================orignal english content==========================
@@ -1774,8 +2026,9 @@ ____________________________________________________________________________-->
          <para>
           All rows in the temporary table will be deleted at the end
           of each transaction block.  Essentially, an automatic <xref
-          linkend="sql-truncate"> is done
-          at each commit.
+		  linkend="sql-truncate"/> is done
+		  at each commit.  When used on a partitioned table, this
+          is not cascaded to its partitions.
          </para>
         </listitem>
        </varlistentry>
@@ -1785,7 +2038,9 @@ ____________________________________________________________________________-->
         <listitem>
          <para>
           The temporary table will be dropped at the end of the current
-          transaction block.
+		  transaction block.  When used on a partitioned table, this action
+          drops its partitions and when used on tables with inheritance
+          children, it drops the dependent children.
          </para>
         </listitem>
        </varlistentry>
@@ -1808,7 +2063,9 @@ ____________________________________________________________________________-->
         <term><literal>DELETE ROWS</literal></term>
         <listitem>
          <para>
-          在每一个事务块结束时将删除临时表中的所有行。实质上，在每一次提交时会完成一次自动的<xref linkend="sql-truncate"/>。
+          在每一个事务块结束时将删除临时表中的所有行。
+		  实质上，在每一次提交时会完成一次自动的<xref linkend="sql-truncate"/>。
+		  当应用于分区表上时，这不会级联到它的分区。
          </para>
         </listitem>
        </varlistentry>
@@ -1817,7 +2074,8 @@ ____________________________________________________________________________-->
         <term><literal>DROP</literal></term>
         <listitem>
          <para>
-          在当前事务块结束时将删除临时表。
+         在当前事务块结束时将删除临时表。
+		 当在分区表上使用时，这个操作会删除他的分区，而在具有继承子级的表上使用时，它将删除依赖的子级。
          </para>
         </listitem>
        </varlistentry>
@@ -1870,11 +2128,11 @@ ____________________________________________________________________________-->
 
   </variablelist>
 
-  <refsect2 id="SQL-CREATETABLE-storage-parameters">
+  <refsect2 id="sql-createtable-storage-parameters">
 <!--==========================orignal english content==========================
-   <title id="SQL-CREATETABLE-storage-parameters-title">Storage Parameters</title>
+   <title id="sql-createtable-storage-parameters-title">Storage Parameters</title>
 ____________________________________________________________________________-->
-   <title id="SQL-CREATETABLE-storage-parameters-title">存储参数</title>
+   <title id="sql-createtable-storage-parameters-title">存储参数</title>
 
 <!--==========================orignal english content==========================
  <indexterm zone="sql-createtable-storage-parameters">
@@ -1891,7 +2149,7 @@ ____________________________________________________________________________-->
     for tables, and for indexes associated with a <literal>UNIQUE</literal>,
     <literal>PRIMARY KEY</literal>, or <literal>EXCLUDE</> constraint.
     Storage parameters for
-    indexes are documented in <xref linkend="SQL-CREATEINDEX">.
+	indexes are documented in <xref linkend="sql-createindex"/>.
     The storage parameters currently
     available for tables are listed below.  For many of these parameters, as
     shown, there is an additional parameter with the same name prefixed with
@@ -1906,7 +2164,11 @@ ____________________________________________________________________________-->
    </para>
 ____________________________________________________________________________-->
    <para>
-    <literal>WITH</literal>子句能够为表或与一个<literal>UNIQUE</literal>、<literal>PRIMARY KEY</literal>或者<literal>EXCLUDE</literal>约束相关的索引指定<firstterm>存储参数</firstterm>。用于索引的存储参数已经在<xref linkend="SQL-CREATEINDEX"/>中介绍过。当前可用于表的存储参数在下文中列出。如下文所示，对于很多这类参数，都有一个名字带有<literal>toast.</literal>前缀的附加参数，它能被用来控制该表的二级<acronym>TOAST</acronym>表（如果存在）的行为（关于 TOAST 详见<xref linkend="storage-toast"/>）。如果一个表的参数值被设置但是相应的<literal>toast.</literal>参数没有被设置，那么 TOAST 表将使用该表的参数值。
+    <literal>WITH</literal>子句能够为表或与一个<literal>UNIQUE</literal>、<literal>PRIMARY KEY</literal>或者<literal>EXCLUDE</literal>约束相关的索引指定<firstterm>存储参数</firstterm>。
+	用于索引的存储参数已经在<xref linkend="sql-createindex"/>中介绍过。
+	当前可用于表的存储参数在下文中列出。
+	如下文所示，对于很多这类参数，都有一个名字带有<literal>toast.</literal>前缀的附加参数，它能被用来控制该表的二级<acronym>TOAST</acronym>表（如果存在）的行为（关于 TOAST 详见<xref linkend="storage-toast"/>）。
+	如果一个表的参数值被设置但是相应的<literal>toast.</literal>参数没有被设置，那么 TOAST 表将使用该表的参数值。
 	不支持为分区表指定这些参数，但可以为单个叶子分区指定它们。
    </para>
 
@@ -1940,6 +2202,42 @@ ____________________________________________________________________________-->
    
    <varlistentry>
 <!--==========================orignal english content==========================
+    <term><literal>toast_tuple_target</literal> (<type>integer</type>)</term>
+____________________________________________________________________________-->
+    <term><literal>toast_tuple_target</literal> (<type>integer</type>)</term>
+    <listitem>
+<!--==========================orignal english content==========================
+     <para>
+      The toast_tuple_target specifies the minimum tuple length required before
+      we try to move long column values into TOAST tables, and is also the
+      target length we try to reduce the length below once toasting begins.
+      This only affects columns marked as either External or Extended
+      and applies only to new tuples - there is no effect on existing rows.
+      By default this parameter is set to allow at least 4 tuples per block,
+      which with the default blocksize will be 2040 bytes. Valid values are
+      between 128 bytes and the (blocksize - header), by default 8160 bytes.
+      Changing this value may not be useful for very short or very long rows.
+      Note that the default setting is often close to optimal, and
+      it is possible that setting this parameter could have negative
+      effects in some cases.
+      This parameter cannot be set for TOAST tables.
+     </para>
+____________________________________________________________________________-->
+     <para>
+	  在我们尝试将长列值移动到TOAST表中之前，toast_tuple_target指定需要的最小元组长度，
+	  也是在toasting开始时尝试减少长度的目标长度。
+	  这仅影响标记为"外部"或"扩展"的列，并且仅适用于新元数 - 对现有行没有影响。
+	  默认情况下此参数设置为允许每个块至少 4 个元组，默认块大小为 2040 字节。
+	  有效值介于 128 字节和(块大小-标头)之间，默认大小为 8160 字节。 
+	  更改此值对于非常短或非常长的行可能没有用处。
+	  请注意默认设置通常接近最佳状态，在某些情况下设置此参数可能会产生负面影响。
+	  不能对TOAST表设置此参数。
+     </para>
+    </listitem>
+   </varlistentry>
+
+   <varlistentry>
+<!--==========================orignal english content==========================
     <term><literal>parallel_workers</> (<type>integer</>)</term>
 ____________________________________________________________________________-->
     <term><literal>parallel_workers</literal> (<type>integer</type>)</term>
@@ -1949,12 +2247,14 @@ ____________________________________________________________________________-->
       This sets the number of workers that should be used to assist a parallel
       scan of this table.  If not set, the system will determine a value based
       on the relation size.  The actual number of workers chosen by the planner
-      may be less, for example due to
-      the setting of <xref linkend="guc-max-worker-processes">.
+	  or by utility statements that use parallel scans may be less, for example
+      due to the setting of <xref linkend="guc-max-worker-processes"/>.
      </para>
 ____________________________________________________________________________-->
      <para>
-      这个参数设置应该被用来辅助对这个表并行扫描的工作者数量。如果没有设置这个参数，系统将基于关系的尺寸来决定一个值。规划器实际选择的工作者数量可能会少于这个参数，例如<xref linkend="guc-max-worker-processes"/>的设置较小就是一种可能的原因。
+      这个参数设置用于辅助并行扫描这个表的工作者数量。
+	  如果没有设置这个参数，系统将基于关系的尺寸来决定一个值。
+	  规划者或使用并行扫描的实用程序选择的工作者数量可能会比较少，例如<xref linkend="guc-max-worker-processes"/>的设置较小就是一种可能的原因。
      </para>
     </listitem>
    </varlistentry>
@@ -2260,7 +2560,7 @@ ____________________________________________________________________________-->
   </refsect2>
  </refsect1>
 
- <refsect1 id="SQL-CREATETABLE-notes">
+ <refsect1 id="sql-createtable-notes">
 <!--==========================orignal english content==========================
   <title>Notes</title>
 ____________________________________________________________________________-->
@@ -2335,7 +2635,8 @@ ____________________________________________________________________________-->
  </refsect1>
 
 
- <refsect1 id="SQL-CREATETABLE-examples">
+
+ <refsect1 id="sql-createtable-examples">
 <!--==========================orignal english content==========================
   <title>Examples</title>
 ____________________________________________________________________________-->
@@ -2469,7 +2770,7 @@ CREATE TABLE distributors (
 <programlisting>
 CREATE TABLE distributors (
     did     integer,
-    name    varchar(40)
+	name    varchar(40),
     CONSTRAINT con1 CHECK (did &gt; 100 AND name &lt;&gt; '')
 );
 </programlisting>
@@ -2481,7 +2782,7 @@ ____________________________________________________________________________-->
 <programlisting>
 CREATE TABLE distributors (
     did     integer,
-    name    varchar(40)
+	name    varchar(40),
     CONSTRAINT con1 CHECK (did &gt; 100 AND name &lt;&gt; '')
 );
 </programlisting>
@@ -2822,6 +3123,27 @@ CREATE TABLE cities (
 
 <!--==========================orignal english content==========================
   <para>
+     Create a hash partitioned table:
+<programlisting>
+CREATE TABLE orders (
+    order_id     bigint not null,
+    cust_id      bigint not null,
+    status       text
+) PARTITION BY HASH (order_id);
+</programlisting></para>
+____________________________________________________________________________-->
+  <para>
+     建立哈希分区表:
+<programlisting>
+CREATE TABLE orders (
+    order_id     bigint not null,
+    cust_id      bigint not null,
+    status       text
+) PARTITION BY HASH (order_id);
+</programlisting></para>
+
+<!--==========================orignal english content==========================
+  <para>
    Create partition of a range partitioned table:
 <programlisting>
 CREATE TABLE measurement_y2016m07
@@ -2925,13 +3247,55 @@ CREATE TABLE cities_ab
 CREATE TABLE cities_ab_10000_to_100000
     PARTITION OF cities_ab FOR VALUES FROM (10000) TO (100000);
 </programlisting></para>
+
+<!--==========================orignal english content==========================
+  <para>
+   Create partitions of a hash partitioned table:
+<programlisting>
+CREATE TABLE orders_p1 PARTITION OF orders
+    FOR VALUES WITH (MODULUS 4, REMAINDER 0);
+CREATE TABLE orders_p2 PARTITION OF orders
+    FOR VALUES WITH (MODULUS 4, REMAINDER 1);
+CREATE TABLE orders_p3 PARTITION OF orders
+    FOR VALUES WITH (MODULUS 4, REMAINDER 2);
+CREATE TABLE orders_p4 PARTITION OF orders
+    FOR VALUES WITH (MODULUS 4, REMAINDER 3);
+</programlisting></para>
+____________________________________________________________________________-->
+  <para>
+   建立哈希分区表的分区：
+<programlisting>
+CREATE TABLE orders_p1 PARTITION OF orders
+    FOR VALUES WITH (MODULUS 4, REMAINDER 0);
+CREATE TABLE orders_p2 PARTITION OF orders
+    FOR VALUES WITH (MODULUS 4, REMAINDER 1);
+CREATE TABLE orders_p3 PARTITION OF orders
+    FOR VALUES WITH (MODULUS 4, REMAINDER 2);
+CREATE TABLE orders_p4 PARTITION OF orders
+    FOR VALUES WITH (MODULUS 4, REMAINDER 3);
+</programlisting></para>
+
+<!--==========================orignal english content==========================
+  <para>
+   Create a default partition:
+<programlisting>
+CREATE TABLE cities_partdef
+    PARTITION OF cities DEFAULT;
+</programlisting></para>
+____________________________________________________________________________-->
+  <para>
+   建立默认分区：
+<programlisting>
+CREATE TABLE cities_partdef
+    PARTITION OF cities DEFAULT;
+</programlisting></para>
  </refsect1>
 
- <refsect1 id="SQL-CREATETABLE-compatibility">
+ <refsect1 id="sql-createtable-compatibility">
 <!--==========================orignal english content==========================
-  <title id="SQL-CREATETABLE-compatibility-title">Compatibility</title>
+  <title id="sql-createtable-compatibility-title">Compatibility</title>
 ____________________________________________________________________________-->
-  <title id="SQL-CREATETABLE-compatibility-title">兼容性</title>
+  <title id="sql-createtable-compatibility-title">Compatibility</title>
 
 <!--==========================orignal english content==========================
   <para>
@@ -3104,6 +3468,53 @@ ____________________________________________________________________________-->
    <para>
     <literal>NULL</literal> <quote>约束</quote>（实际上是一个非约束）是一个<productname>PostgreSQL</productname>对 SQL 标准的扩展，它也被包括（以及对称的<literal>NOT NULL</literal>约束）在一些其他的数据库系统中以实现兼容性。因为它是任意列的默认值，它的存在就像噪声一样。
    </para>
+  </refsect2>
+
+  <refsect2>
+<!--==========================orignal english content==========================
+   <title>Constraint Naming</title>
+____________________________________________________________________________-->
+   <title>Constraint Naming</title>
+
+<!--==========================orignal english content==========================
+   <para>
+    The SQL standard says that table and domain constraints must have names
+    that are unique across the schema containing the table or domain.
+    <productname>PostgreSQL</productname> is laxer: it only requires
+    constraint names to be unique across the constraints attached to a
+    particular table or domain.  However, this extra freedom does not exist
+    for index-based constraints (<literal>UNIQUE</literal>,
+    <literal>PRIMARY KEY</literal>, and <literal>EXCLUDE</literal>
+    constraints), because the associated index is named the same as the
+    constraint, and index names must be unique across all relations within
+    the same schema.
+   </para>
+____________________________________________________________________________-->
+   <para>
+	SQL标准规定在包含表或域的模式范围内表和域的约束必须具有唯一的名称。
+	<productname>PostgreSQL</productname>是比较宽松的：它只需要约束名称在附加到特定表或域的约束之间是唯一的。
+	但是，对于基于索引的约束(<literal>UNIQUE</literal>,<literal>PRIMARY KEY</literal>, and <literal>EXCLUDE</literal>constraints)，
+	这个特别的自由度并不存在，
+	因为关联的索引被命名为与约束相同的名称，并且索引名称在相同模式的所有关系中必须是唯一的。	
+   </para>
+
+<!--==========================orignal english content==========================
+   <para>
+    Currently, <productname>PostgreSQL</productname> does not record names
+    for <literal>NOT NULL</literal> constraints at all, so they are not
+    subject to the uniqueness restriction.  This might change in a future
+    release.
+   </para>
+____________________________________________________________________________-->
+   <para>
+    Currently, <productname>PostgreSQL</productname> does not record names
+    for <literal>NOT NULL</literal> constraints at all, so they are not
+    subject to the uniqueness restriction.  This might change in a future
+    release.
+	当前，<productname>PostgreSQL</productname>没有记录<literal>NOT NULL</literal>约束的名称，
+	因此它们不受唯一性限制的影响。这在将来的版本中可能会改变。	
+   </para>
+   
   </refsect2>
 
   <refsect2>

--- a/postgresql/doc/src/sgml/ref/create_transform.sgml
+++ b/postgresql/doc/src/sgml/ref/create_transform.sgml
@@ -1,6 +1,6 @@
 <!-- doc/src/sgml/ref/create_transform.sgml -->
 
-<refentry id="SQL-CREATETRANSFORM">
+<refentry id="sql-createtransform">
 <!--==========================orignal english content==========================
  <indexterm zone="sql-createtransform">
   <primary>CREATE TRANSFORM</primary>
@@ -287,7 +287,7 @@ ____________________________________________________________________________-->
 <programlisting>
 CREATE TYPE hstore ...;
 
-CREATE LANGUAGE plpythonu ...;
+CREATE EXTENSION plpythonu;
 </programlisting>
    Then create the necessary functions:
 <programlisting>
@@ -306,7 +306,7 @@ CREATE TRANSFORM FOR hstore LANGUAGE plpythonu (
     TO SQL WITH FUNCTION plpython_to_hstore(internal)
 );
 </programlisting>
-   In practice, these commands would be wrapped up in extensions.
+   In practice, these commands would be wrapped up in an extension.
   </para>
 ____________________________________________________________________________-->
   <para>
@@ -315,7 +315,7 @@ ____________________________________________________________________________-->
 <programlisting>
 CREATE TYPE hstore ...;
 
-CREATE LANGUAGE plpythonu ...;
+CREATE EXTENSION plpythonu;
 </programlisting>
    然后创建需要的函数：
 <programlisting>

--- a/postgresql/doc/src/sgml/ref/pg_controldata.sgml
+++ b/postgresql/doc/src/sgml/ref/pg_controldata.sgml
@@ -3,7 +3,7 @@ doc/src/sgml/ref/pg_controldata.sgml
 PostgreSQL documentation
 -->
 
-<refentry id="APP-PGCONTROLDATA">
+<refentry id="app-pgcontroldata">
 <!--==========================orignal english content==========================
  <indexterm zone="app-pgcontroldata">
   <primary>pg_controldata</primary>
@@ -42,17 +42,29 @@ ____________________________________________________________________________-->
   <cmdsynopsis>
    <command>pg_controldata</command>
    <arg choice="opt"><replaceable class="parameter">option</replaceable></arg>
-   <arg choice="opt"><arg choice="opt"><option>-D</option></arg> <replaceable class="parameter">datadir</replaceable></arg>
+   <group choice="opt">
+   <group choice="opt">
+   <arg choice="plain"><option>--pgdata</option></arg>
+   <arg choice="plain"><option>-D</option></arg>
+   </group>
+   <replaceable class="parameter"> datadir</replaceable>
+   </group>
   </cmdsynopsis>
 ____________________________________________________________________________-->
   <cmdsynopsis>
    <command>pg_controldata</command>
    <arg choice="opt"><replaceable class="parameter">option</replaceable></arg>
-   <arg choice="opt"><arg choice="opt"><option>-D</option></arg> <replaceable class="parameter">datadir</replaceable></arg>
+   <group choice="opt">
+   <group choice="opt">
+   <arg choice="plain"><option>--pgdata</option></arg>
+   <arg choice="plain"><option>-D</option></arg>
+   </group>
+   <replaceable class="parameter"> datadir</replaceable>
+   </group>
   </cmdsynopsis>
  </refsynopsisdiv>
 
- <refsect1 id="R1-APP-PGCONTROLDATA-1">
+ <refsect1 id="r1-app-pgcontroldata-1">
 <!--==========================orignal english content==========================
   <title>Description</title>
 ____________________________________________________________________________-->
@@ -60,7 +72,7 @@ ____________________________________________________________________________-->
 <!--==========================orignal english content==========================
   <para>
    <command>pg_controldata</command> prints information initialized during
-   <command>initdb</>, such as the catalog version.
+   <command>initdb</command>, such as the catalog version.
    It also shows information about write-ahead logging and checkpoint
    processing.  This information is cluster-wide, and not specific to any one
    database.
@@ -75,10 +87,10 @@ ____________________________________________________________________________-->
    This utility can only be run by the user who initialized the cluster because
    it requires read access to the data directory.
    You can specify the data directory on the command line, or use
-   the environment variable <envar>PGDATA</>.  This utility supports the options
-   <option>-V</> and <option>-&minus;version</>, which print the
+   the environment variable <envar>PGDATA</envar>.  This utility supports the options
+   <option>-V</option> and <option>-&minus;version</option>, which print the
    <application>pg_controldata</application> version and exit.  It also
-   supports options <option>-?</> and <option>-&minus;help</>, which output the
+   supports options <option>-?</option> and <option>-&minus;help</option>, which output the
    supported arguments.
   </para>
 ____________________________________________________________________________-->

--- a/postgresql/doc/src/sgml/ref/pgtesttiming.sgml
+++ b/postgresql/doc/src/sgml/ref/pgtesttiming.sgml
@@ -55,7 +55,7 @@ ____________________________________________________________________________-->
 
 <!--==========================orignal english content==========================
  <para>
-  <application>pg_test_timing</> is a tool to measure the timing overhead
+  <application>pg_test_timing</application> is a tool to measure the timing overhead
   on your system and confirm that the system time never moves backwards.
   Systems that are slow to collect timing data can give less accurate
   <command>EXPLAIN ANALYZE</command> results.
@@ -93,8 +93,8 @@ ____________________________________________________________________________-->
      </varlistentry>
 
      <varlistentry>
-      <term><option>-V</></term>
-      <term><option>-&minus;version</></term>
+      <term><option>-V</option></term>
+      <term><option>-&minus;version</option></term>
       <listitem>
        <para>
         Print the <application>pg_test_timing</application> version and exit.
@@ -103,8 +103,8 @@ ____________________________________________________________________________-->
      </varlistentry>
 
      <varlistentry>
-      <term><option>-?</></term>
-      <term><option>-&minus;help</></term>
+      <term><option>-?</option></term>
+      <term><option>-&minus;help</option></term>
       <listitem>
        <para>
         Show help about <application>pg_test_timing</application> command line
@@ -175,7 +175,7 @@ ____________________________________________________________________________-->
    nanoseconds. This example from an Intel i7-860 system using a TSC clock
    source shows excellent performance:
 
-<screen>
+<screen><![CDATA[
 Testing timing overhead for 3 seconds.
 Per loop time including overhead: 35.96 ns
 Histogram of timing durations:
@@ -185,13 +185,13 @@ Histogram of timing durations:
      4      0.00015        126
      8      0.00002         13
     16      0.00000          2
-</screen>
+]]></screen>
   </para>
 ____________________________________________________________________________-->
   <para>
    好的结果将显示大部分（>90%）的单个计时调用用时都小于 1 微秒。每次循环的平均开销将会更低，低于 100 纳秒。下面的例子来自于一台使用了一份 TSC 时钟源码的 Intel i7-860 系统，它展示了非常好的性能：
 
-<screen>
+<screen><![CDATA[
 Testing timing overhead for 3 seconds.
 Per loop time including overhead: 35.96 ns
 Histogram of timing durations:
@@ -201,7 +201,7 @@ Histogram of timing durations:
      4      0.00015        126  
      8      0.00002         13  
     16      0.00000          2  
-</screen>
+]]></screen>
   </para>
 
 <!--==========================orignal english content==========================
@@ -278,7 +278,7 @@ ____________________________________________________________________________-->
    possible from switching to the slower acpi_pm time source, on the same
    system used for the fast results above:
 
-<screen>
+<screen><![CDATA[
 # cat /sys/devices/system/clocksource/clocksource0/available_clocksource
 tsc hpet acpi_pm
 # echo acpi_pm > /sys/devices/system/clocksource/clocksource0/current_clocksource
@@ -291,13 +291,13 @@ Histogram of timing durations:
      4      0.07810       3241
      8      0.01357        563
     16      0.00007          3
-</screen>
+]]></screen>
   </para>
 ____________________________________________________________________________-->
   <para>
    在一些较新的 Linux 系统上，可以在任何时候更改用来收集计时数据的时钟来源。第二个例子显示了在上述快速结果的相同系统上切换到较慢的 acpi_pm 时间源可能带来的降速：
 
-<screen>
+<screen><![CDATA[
 # cat /sys/devices/system/clocksource/clocksource0/available_clocksource
 tsc hpet acpi_pm
 # echo acpi_pm > /sys/devices/system/clocksource/clocksource0/current_clocksource
@@ -310,7 +310,7 @@ Histogram of timing durations:
      4      0.07810       3241  
      8      0.01357        563  
     16      0.00007          3  
-</screen>
+]]></screen>
   </para>
 
 <!--==========================orignal english content==========================
@@ -367,7 +367,7 @@ kern.timecounter.hardware: ACPI-fast -> TSC
    implementation, which can have good resolution when it's backed by fast
    enough timing hardware, as in this example:
 
-<screen>
+<screen><![CDATA[
 $ cat /sys/devices/system/clocksource/clocksource0/available_clocksource
 jiffies
 $ dmesg | grep time.c
@@ -384,12 +384,12 @@ Histogram of timing durations:
      8      0.00007         22
     16      0.00000          1
     32      0.00000          1
-</screen></para>
+]]></screen></para>
 ____________________________________________________________________________-->
   <para>
    其他系统可能只允许在启动时设定时间源。在旧的 Linux 系统上，“clock”内核设置是做这类更改的唯一方法。并且即使在一些更近的系统上，对于一个时钟源你将只能看到唯一的选项 "jiffies"。Jiffies 是老的 Linux 软件时钟实现，当有足够快的计时硬件支持时，它能够具有很好的解析度，就像在这个例子中：
 
-<screen>
+<screen><![CDATA[
 $ cat /sys/devices/system/clocksource/clocksource0/available_clocksource
 jiffies
 $ dmesg | grep time.c
@@ -406,7 +406,7 @@ Histogram of timing durations:
      8      0.00007         22  
     16      0.00000          1  
     32      0.00000          1  
-</screen></para>
+]]></screen></para>
 
  </refsect2>
 

--- a/postgresql/doc/src/sgml/ref/prepare.sgml
+++ b/postgresql/doc/src/sgml/ref/prepare.sgml
@@ -3,7 +3,7 @@ doc/src/sgml/ref/prepare.sgml
 PostgreSQL documentation
 -->
 
-<refentry id="SQL-PREPARE">
+<refentry id="sql-prepare">
 <!--==========================orignal english content==========================
  <indexterm zone="sql-prepare">
   <primary>PREPARE</primary>
@@ -86,11 +86,11 @@ ____________________________________________________________________________-->
    Prepared statements can take parameters: values that are
    substituted into the statement when it is executed. When creating
    the prepared statement, refer to parameters by position, using
-   <literal>$1</>, <literal>$2</>, etc. A corresponding list of
+   <literal>$1</literal>, <literal>$2</literal>, etc. A corresponding list of
    parameter data types can optionally be specified. When a
    parameter's data type is not specified or is declared as
    <literal>unknown</literal>, the type is inferred from the context
-   in which the parameter is used (if possible). When executing the
+   in which the parameter is first referenced (if possible). When executing the
    statement, specify the actual values for these parameters in the
    <command>EXECUTE</command> statement.  Refer to <xref
    linkend="sql-execute"> for more
@@ -98,7 +98,7 @@ ____________________________________________________________________________-->
   </para>
 ____________________________________________________________________________-->
   <para>
-   预备语句可以接受参数：在执行时会被替换到语句中的值。在创建预备语句时，可以用位置引用参数，如<literal>$1</literal>、<literal>$2</literal>等。也可以选择性地指定参数数据类型的一个列表。当一个参数的数据类型没有被指定或者被声明为<literal>unknown</literal>时，其类型会从该参数被使用的环境中推知（如果可能）。在执行该语句时，在<command>EXECUTE</command>语句中为这些参数指定实际值。更多有关于此的信息可参考<xref linkend="sql-execute"/>。
+   预备语句可以接受参数：在执行时会被替换到语句中的值。在创建预备语句时，可以用位置引用参数，如<literal>$1</literal>、<literal>$2</literal>等。也可以选择性地指定参数数据类型的一个列表。当一个参数的数据类型没有被指定或者被声明为<literal>unknown</literal>时，其类型会从该参数第一次被引用的环境中推知（如果可能）。在执行该语句时，在<command>EXECUTE</command>语句中为这些参数指定实际值。更多有关于此的信息可参考<xref linkend="sql-execute"/>。
   </para>
 
 <!--==========================orignal english content==========================
@@ -171,13 +171,13 @@ ____________________________________________________________________________-->
       The data type of a parameter to the prepared statement.  If the
       data type of a particular parameter is unspecified or is
       specified as <literal>unknown</literal>, it will be inferred
-      from the context in which the parameter is used. To refer to the
+      from the context in which the parameter is first referenced. To refer to the
       parameters in the prepared statement itself, use
       <literal>$1</literal>, <literal>$2</literal>, etc.
      </para>
 ____________________________________________________________________________-->
      <para>
-      预备语句一个参数的数据类型。如果一个特定参数的数据类型没有被指定或者被指定为<literal>unknown</literal>，将从该参数被使用的环境中推得。要在预备语句本身中引用参数，可以使用
+      预备语句一个参数的数据类型。如果一个特定参数的数据类型没有被指定或者被指定为<literal>unknown</literal>，将从该参数第一次被引用的环境中推得。要在预备语句本身中引用参数，可以使用
       <literal>$1</literal>、<literal>$2</literal>等。
      </para>
     </listitem>
@@ -191,8 +191,8 @@ ____________________________________________________________________________-->
     <listitem>
 <!--==========================orignal english content==========================
      <para>
-      Any <command>SELECT</>, <command>INSERT</>, <command>UPDATE</>,
-      <command>DELETE</>, or <command>VALUES</> statement.
+      Any <command>SELECT</command>, <command>INSERT</command>, <command>UPDATE</command>,
+      <command>DELETE</command>, or <command>VALUES</command> statement.
      </para>
 ____________________________________________________________________________-->
      <para>
@@ -203,7 +203,7 @@ ____________________________________________________________________________-->
   </variablelist>
  </refsect1>
 
- <refsect1 id="SQL-PREPARE-notes">
+ <refsect1 id="sql-prepare-notes">
 <!--==========================orignal english content==========================
   <title>Notes</title>
 ____________________________________________________________________________-->
@@ -249,9 +249,9 @@ ____________________________________________________________________________-->
   <para>
    To examine the query plan <productname>PostgreSQL</productname> is using
    for a prepared statement, use <xref linkend="sql-explain">, e.g.
-   <command>EXPLAIN EXECUTE</>.
+   <command>EXPLAIN EXECUTE</command>.
    If a generic plan is in use, it will contain parameter symbols
-   <literal>$<replaceable>n</></literal>, while a custom plan will have the
+   <literal>$<replaceable>n</replaceable></literal>, while a custom plan will have the
    supplied parameter values substituted into it.
    The row estimates in the generic plan reflect the selectivity
    computed for the parameters.
@@ -276,13 +276,13 @@ ____________________________________________________________________________-->
 <!--==========================orignal english content==========================
   <para>
    Although the main point of a prepared statement is to avoid repeated parse
-   analysis and planning of the statement, <productname>PostgreSQL</> will
+   analysis and planning of the statement, <productname>PostgreSQL</productname> will
    force re-analysis and re-planning of the statement before using it
    whenever database objects used in the statement have undergone
    definitional (DDL) changes since the previous use of the prepared
    statement.  Also, if the value of <xref linkend="guc-search-path"> changes
    from one use to the next, the statement will be re-parsed using the new
-   <varname>search_path</>.  (This latter behavior is new as of
+   <varname>search_path</varname>.  (This latter behavior is new as of
    <productname>PostgreSQL</productname> 9.3.)  These rules make use of a
    prepared statement semantically almost equivalent to re-submitting the
    same query text over and over, but with a performance benefit if no object
@@ -290,7 +290,7 @@ ____________________________________________________________________________-->
    across uses.  An example of a case where the semantic equivalence is not
    perfect is that if the statement refers to a table by an unqualified name,
    and then a new table of the same name is created in a schema appearing
-   earlier in the <varname>search_path</>, no automatic re-parse will occur
+   earlier in the <varname>search_path</varname>, no automatic re-parse will occur
    since no object used in the statement changed.  However, if some other
    change forces a re-parse, the new table will be referenced in subsequent
    uses.
@@ -349,7 +349,7 @@ EXECUTE usrrptplan(1, current_date);
 </programlisting>
 
    Note that the data type of the second parameter is not specified,
-   so it is inferred from the context in which <literal>$2</> is used.
+   so it is inferred from the context in which <literal>$2</literal> is used.
   </para>
 ____________________________________________________________________________-->
   <para>

--- a/postgresql/doc/src/sgml/ref/prepare_transaction.sgml
+++ b/postgresql/doc/src/sgml/ref/prepare_transaction.sgml
@@ -3,7 +3,7 @@ doc/src/sgml/ref/prepare_transaction.sgml
 PostgreSQL documentation
 -->
 
-<refentry id="SQL-PREPARE-TRANSACTION">
+<refentry id="sql-prepare-transaction">
 <!--==========================orignal english content==========================
  <indexterm zone="sql-prepare-transaction">
   <primary>PREPARE TRANSACTION</primary>
@@ -186,16 +186,16 @@ ____________________________________________________________________________-->
 <!--==========================orignal english content==========================
   <para>
    It is not currently allowed to <command>PREPARE</> a transaction that
-   has executed any operations involving temporary tables,
-   created any cursors <literal>WITH HOLD</>, or executed
-   <command>LISTEN</>, <command>UNLISTEN</>, or
+   has executed any operations involving temporary tables or the session's
+   temporary namespace, created any cursors <literal>WITH HOLD</literal>, or
+   executed <command>LISTEN</command>, <command>UNLISTEN</command>, or
    <command>NOTIFY</>.
    Those features are too tightly
    tied to the current session to be useful in a transaction to be prepared.
   </para>
 ____________________________________________________________________________-->
   <para>
-   当前在已经执行过任何涉及到临时表、创建带
+   当前在已经执行过任何涉及到临时表或者会话的临时命名空间、创建带
    <literal>WITH HOLD</literal>的游标或者执行
    <command>LISTEN</command>、<command>UNLISTEN</command>或<command>NOTIFY</command>的
    事务中，不允许<command>PREPARE</command>该事务。这些特性与当前会话

--- a/postgresql/doc/src/sgml/ref/prepare_transaction.sgml
+++ b/postgresql/doc/src/sgml/ref/prepare_transaction.sgml
@@ -90,7 +90,7 @@ ____________________________________________________________________________-->
 <!--==========================orignal english content==========================
   <para>
    From the point of view of the issuing session, <command>PREPARE
-   TRANSACTION</command> is not unlike a <command>ROLLBACK</> command:
+   TRANSACTION</command> is not unlike a <command>ROLLBACK</command> command:
    after executing it, there is no active current transaction, and the
    effects of the prepared transaction are no longer visible.  (The effects
    will become visible again if the transaction is committed.)
@@ -106,7 +106,7 @@ ____________________________________________________________________________-->
 <!--==========================orignal english content==========================
   <para>
    If the <command>PREPARE TRANSACTION</command> command fails for any
-   reason, it becomes a <command>ROLLBACK</>: the current transaction
+   reason, it becomes a <command>ROLLBACK</command>: the current transaction
    is canceled.
   </para>
 ____________________________________________________________________________-->
@@ -132,7 +132,7 @@ ____________________________________________________________________________-->
 <!--==========================orignal english content==========================
      <para>
       An arbitrary identifier that later identifies this transaction for
-      <command>COMMIT PREPARED</> or <command>ROLLBACK PREPARED</>.
+      <command>COMMIT PREPARED</command> or <command>ROLLBACK PREPARED</command>.
       The identifier must be written as a string literal, and must be
       less than 200 bytes long.  It must not be the same as the identifier
       used for any currently prepared transaction.
@@ -157,12 +157,12 @@ ____________________________________________________________________________-->
 
 <!--==========================orignal english content==========================
   <para>
-   <command>PREPARE TRANSACTION</> is not intended for use in applications
+   <command>PREPARE TRANSACTION</command> is not intended for use in applications
    or interactive sessions. Its purpose is to allow an external
    transaction manager to perform atomic global transactions across multiple
    databases or other transactional resources. Unless you're writing a
    transaction manager, you probably shouldn't be using <command>PREPARE
-   TRANSACTION</>.
+   TRANSACTION</command>.
   </para>
 ____________________________________________________________________________-->
   <para>
@@ -185,11 +185,11 @@ ____________________________________________________________________________-->
 
 <!--==========================orignal english content==========================
   <para>
-   It is not currently allowed to <command>PREPARE</> a transaction that
+   It is not currently allowed to <command>PREPARE</command> a transaction that
    has executed any operations involving temporary tables or the session's
    temporary namespace, created any cursors <literal>WITH HOLD</literal>, or
    executed <command>LISTEN</command>, <command>UNLISTEN</command>, or
-   <command>NOTIFY</>.
+   <command>NOTIFY</command>.
    Those features are too tightly
    tied to the current session to be useful in a transaction to be prepared.
   </para>
@@ -204,13 +204,13 @@ ____________________________________________________________________________-->
 
 <!--==========================orignal english content==========================
   <para>
-   If the transaction modified any run-time parameters with <command>SET</>
-   (without the <literal>LOCAL</> option),
-   those effects persist after <command>PREPARE TRANSACTION</>, and will not
+   If the transaction modified any run-time parameters with <command>SET</command>
+   (without the <literal>LOCAL</literal> option),
+   those effects persist after <command>PREPARE TRANSACTION</command>, and will not
    be affected by any later <command>COMMIT PREPARED</command> or
    <command>ROLLBACK PREPARED</command>.  Thus, in this one respect
-   <command>PREPARE TRANSACTION</> acts more like <command>COMMIT</> than
-   <command>ROLLBACK</>.
+   <command>PREPARE TRANSACTION</command> acts more like <command>COMMIT</command> than
+   <command>ROLLBACK</command>.
   </para>
 ____________________________________________________________________________-->
   <para>
@@ -238,7 +238,7 @@ ____________________________________________________________________________-->
 <!--==========================orignal english content==========================
    <para>
     It is unwise to leave transactions in the prepared state for a long time.
-    This will interfere with the ability of <command>VACUUM</> to reclaim
+    This will interfere with the ability of <command>VACUUM</command> to reclaim
     storage, and in extreme cases could cause the database to shut down
     to prevent transaction ID wraparound (see <xref
     linkend="vacuum-for-wraparound">).  Keep in mind also that the transaction
@@ -284,7 +284,7 @@ ____________________________________________________________________________-->
 <!--==========================orignal english content==========================
   <para>
    Prepare the current transaction for two-phase commit, using
-   <literal>foobar</> as the transaction identifier:
+   <literal>foobar</literal> as the transaction identifier:
 
 <programlisting>
 PREPARE TRANSACTION 'foobar';

--- a/postgresql/doc/src/sgml/ref/refresh_materialized_view.sgml
+++ b/postgresql/doc/src/sgml/ref/refresh_materialized_view.sgml
@@ -182,9 +182,9 @@ ____________________________________________________________________________-->
   <para>
    While the default index for future
    <xref linkend="sql-cluster">
-   operations is retained, <command>REFRESH MATERIALIZED VIEW</> does not
+   operations is retained, <command>REFRESH MATERIALIZED VIEW</command> does not
    order the generated rows based on this property. If you want the data
-   to be ordered upon generation, you must use an <literal>ORDER BY</>
+   to be ordered upon generation, you must use an <literal>ORDER BY</literal>
    clause in the backing query.
   </para>
 ____________________________________________________________________________-->

--- a/postgresql/doc/src/sgml/ref/refresh_materialized_view.sgml
+++ b/postgresql/doc/src/sgml/ref/refresh_materialized_view.sgml
@@ -3,7 +3,7 @@ doc/src/sgml/ref/refresh_materialized_view.sgml
 PostgreSQL documentation
 -->
 
-<refentry id="SQL-REFRESHMATERIALIZEDVIEW">
+<refentry id="sql-refreshmaterializedview">
 <!--==========================orignal english content==========================
  <indexterm zone="sql-refreshmaterializedview">
   <primary>REFRESH MATERIALIZED VIEW</primary>
@@ -59,7 +59,8 @@ ____________________________________________________________________________-->
 <!--==========================orignal english content==========================
   <para>
    <command>REFRESH MATERIALIZED VIEW</command> completely replaces the
-   contents of a materialized view.  The old contents are discarded.  If
+   contents of a materialized view.  To execute this command you must be the
+   owner of the materialized view.  The old contents are discarded.  If
    <literal>WITH DATA</literal> is specified (or defaults) the backing query
    is executed to provide the new data, and the materialized view is left in a
    scannable state.  If <literal>WITH NO DATA</literal> is specified no new
@@ -69,7 +70,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
   <para>
    <command>REFRESH MATERIALIZED VIEW</command>完全替换一个
-   物化视图的内容。旧的内容会被抛弃。如果指定了
+   物化视图的内容。你必须是该物化视图的属主才能执行这个命令.旧的内容会被抛弃。如果指定了
    <literal>WITH DATA</literal>（或者作为默认值），支持查询将被执行以
    提供新的数据，并且会让物化视图将处于可扫描的状态。如果指定了
    <literal>WITH NO DATA</literal>，则不会生成新数据并且会让物化视图
@@ -180,7 +181,7 @@ ____________________________________________________________________________-->
 <!--==========================orignal english content==========================
   <para>
    While the default index for future
-   <xref linkend="SQL-CLUSTER">
+   <xref linkend="sql-cluster">
    operations is retained, <command>REFRESH MATERIALIZED VIEW</> does not
    order the generated rows based on this property. If you want the data
    to be ordered upon generation, you must use an <literal>ORDER BY</>
@@ -188,7 +189,7 @@ ____________________________________________________________________________-->
   </para>
 ____________________________________________________________________________-->
   <para>
-   虽然用于未来的<xref linkend="SQL-CLUSTER"/>操作的默认索引会被保持，
+   虽然用于未来的<xref linkend="sql-cluster"/>操作的默认索引会被保持，
    <command>REFRESH MATERIALIZED VIEW</command>不会基于这个属性排序产生
    的行。如果希望数据在产生时排序，必须在支持查询中使用
    <literal>ORDER BY</literal>子句。

--- a/postgresql/doc/src/sgml/ref/revoke.sgml
+++ b/postgresql/doc/src/sgml/ref/revoke.sgml
@@ -254,13 +254,13 @@ ____________________________________________________________________________-->
    Note that any particular role will have the sum
    of privileges granted directly to it, privileges granted to any role it
    is presently a member of, and privileges granted to
-   <literal>PUBLIC</literal>.  Thus, for example, revoking <literal>SELECT</> privilege
+   <literal>PUBLIC</literal>.  Thus, for example, revoking <literal>SELECT</literal> privilege
    from <literal>PUBLIC</literal> does not necessarily mean that all roles
-   have lost <literal>SELECT</> privilege on the object: those who have it granted
+   have lost <literal>SELECT</literal> privilege on the object: those who have it granted
    directly or via another role will still have it.  Similarly, revoking
-   <literal>SELECT</> from a user might not prevent that user from using
-   <literal>SELECT</> if <literal>PUBLIC</literal> or another membership
-   role still has <literal>SELECT</> rights.
+   <literal>SELECT</literal> from a user might not prevent that user from using
+   <literal>SELECT</literal> if <literal>PUBLIC</literal> or another membership
+   role still has <literal>SELECT</literal> rights.
   </para>
 ____________________________________________________________________________-->
   <para>
@@ -328,10 +328,10 @@ ____________________________________________________________________________-->
 
 <!--==========================orignal english content==========================
   <para>
-   When revoking membership in a role, <literal>GRANT OPTION</> is instead
-   called <literal>ADMIN OPTION</>, but the behavior is similar.
+   When revoking membership in a role, <literal>GRANT OPTION</literal> is instead
+   called <literal>ADMIN OPTION</literal>, but the behavior is similar.
    Note also that this form of the command does not
-   allow the noise word <literal>GROUP</>.
+   allow the noise word <literal>GROUP</literal>.
   </para>
 ____________________________________________________________________________-->
   <para>
@@ -352,7 +352,7 @@ ____________________________________________________________________________-->
    Use <xref linkend="app-psql">'s <command>\dp</command> command to
    display the privileges granted on existing tables and columns.  See <xref
    linkend="sql-grant"> for information about the
-   format.  For non-table objects there are other <command>\d</> commands
+   format.  For non-table objects there are other <command>\d</command> commands
    that can display their privileges.
   </para>
 ____________________________________________________________________________-->
@@ -388,12 +388,12 @@ ____________________________________________________________________________-->
 
 <!--==========================orignal english content==========================
    <para>
-    When a non-owner of an object attempts to <command>REVOKE</> privileges
+    When a non-owner of an object attempts to <command>REVOKE</command> privileges
     on the object, the command will fail outright if the user has no
     privileges whatsoever on the object.  As long as some privilege is
     available, the command will proceed, but it will revoke only those
     privileges for which the user has grant options.  The <command>REVOKE ALL
-    PRIVILEGES</> forms will issue a warning message if no grant options are
+    PRIVILEGES</command> forms will issue a warning message if no grant options are
     held, while the other forms will issue a warning if grant options for
     any of the privileges specifically named in the command are not held.
     (In principle these statements apply to the object owner as well, but
@@ -413,7 +413,7 @@ ____________________________________________________________________________-->
 
 <!--==========================orignal english content==========================
    <para>
-    If a superuser chooses to issue a <command>GRANT</> or <command>REVOKE</>
+    If a superuser chooses to issue a <command>GRANT</command> or <command>REVOKE</command>
     command, the command is performed as though it were issued by the
     owner of the affected object.  Since all privileges ultimately come
     from the object owner (possibly indirectly via chains of grant options),
@@ -431,18 +431,18 @@ ____________________________________________________________________________-->
 
 <!--==========================orignal english content==========================
    <para>
-    <command>REVOKE</> can also be done by a role
+    <command>REVOKE</command> can also be done by a role
     that is not the owner of the affected object, but is a member of the role
     that owns the object, or is a member of a role that holds privileges
     <literal>WITH GRANT OPTION</literal> on the object.  In this case the
     command is performed as though it were issued by the containing role that
     actually owns the object or holds the privileges
     <literal>WITH GRANT OPTION</literal>.  For example, if table
-    <literal>t1</> is owned by role <literal>g1</>, of which role
-    <literal>u1</> is a member, then <literal>u1</> can revoke privileges
-    on <literal>t1</> that are recorded as being granted by <literal>g1</>.
-    This would include grants made by <literal>u1</> as well as by other
-    members of role <literal>g1</>.
+    <literal>t1</literal> is owned by role <literal>g1</literal>, of which role
+    <literal>u1</literal> is a member, then <literal>u1</literal> can revoke privileges
+    on <literal>t1</literal> that are recorded as being granted by <literal>g1</literal>.
+    This would include grants made by <literal>u1</literal> as well as by other
+    members of role <literal>g1</literal>.
    </para>
 ____________________________________________________________________________-->
    <para>
@@ -459,11 +459,11 @@ ____________________________________________________________________________-->
 
 <!--==========================orignal english content==========================
    <para>
-    If the role executing <command>REVOKE</> holds privileges
+    If the role executing <command>REVOKE</command> holds privileges
     indirectly via more than one role membership path, it is unspecified
     which containing role will be used to perform the command.  In such cases
-    it is best practice to use <command>SET ROLE</> to become the specific
-    role you want to do the <command>REVOKE</> as.  Failure to do so might
+    it is best practice to use <command>SET ROLE</command> to become the specific
+    role you want to do the <command>REVOKE</command> as.  Failure to do so might
     lead to revoking privileges other than the ones you intended, or not
     revoking anything at all.
    </para>
@@ -512,7 +512,7 @@ REVOKE ALL PRIVILEGES ON kinds FROM manuel;
 </programlisting>
 
    Note that this actually means <quote>revoke all privileges that I
-   granted</>.
+   granted</quote>.
   </para>
 ____________________________________________________________________________-->
   <para>
@@ -528,7 +528,7 @@ REVOKE ALL PRIVILEGES ON kinds FROM manuel;
 
 <!--==========================orignal english content==========================
   <para>
-   Revoke membership in role <literal>admins</> from user <literal>joe</>:
+   Revoke membership in role <literal>admins</literal> from user <literal>joe</literal>:
 
 <programlisting>
 REVOKE admins FROM joe;
@@ -553,7 +553,7 @@ ____________________________________________________________________________-->
     The compatibility notes of the <xref linkend="sql-grant"> command
     apply analogously to <command>REVOKE</command>.
     The keyword <literal>RESTRICT</literal> or <literal>CASCADE</literal>
-    is required according to the standard, but <productname>PostgreSQL</>
+    is required according to the standard, but <productname>PostgreSQL</productname>
     assumes <literal>RESTRICT</literal> by default.
    </para>
 ____________________________________________________________________________-->

--- a/postgresql/doc/src/sgml/ref/revoke.sgml
+++ b/postgresql/doc/src/sgml/ref/revoke.sgml
@@ -3,7 +3,7 @@ doc/src/sgml/ref/revoke.sgml
 PostgreSQL documentation
 -->
 
-<refentry id="SQL-REVOKE">
+<refentry id="sql-revoke">
 <!--==========================orignal english content==========================
  <indexterm zone="sql-revoke">
   <primary>REVOKE</primary>
@@ -89,8 +89,8 @@ REVOKE [ GRANT OPTION FOR ]
 
 REVOKE [ GRANT OPTION FOR ]
     { EXECUTE | ALL [ PRIVILEGES ] }
-    ON { FUNCTION <replaceable>function_name</replaceable> [ ( [ [ <replaceable class="parameter">argmode</replaceable> ] [ <replaceable class="parameter">arg_name</replaceable> ] <replaceable class="parameter">arg_type</replaceable> [, ...] ] ) ] [, ...]
-         | ALL FUNCTIONS IN SCHEMA <replaceable>schema_name</replaceable> [, ...] }
+    ON { { FUNCTION | PROCEDURE | ROUTINE } <replaceable>function_name</replaceable> [ ( [ [ <replaceable class="parameter">argmode</replaceable> ] [ <replaceable class="parameter">arg_name</replaceable> ] <replaceable class="parameter">arg_type</replaceable> [, ...] ] ) ] [, ...]
+         | ALL { FUNCTIONS | PROCEDURES | ROUTINES } IN SCHEMA <replaceable>schema_name</replaceable> [, ...] }
     FROM { [ GROUP ] <replaceable class="parameter">role_name</replaceable> | PUBLIC } [, ...]
     [ CASCADE | RESTRICT ]
 
@@ -220,7 +220,7 @@ REVOKE [ ADMIN OPTION FOR ]
 </synopsis>
  </refsynopsisdiv>
 
- <refsect1 id="SQL-REVOKE-description">
+ <refsect1 id="sql-revoke-description">
 <!--==========================orignal english content==========================
   <title>Description</title>
 ____________________________________________________________________________-->
@@ -341,7 +341,7 @@ ____________________________________________________________________________-->
   </para>
  </refsect1>
 
- <refsect1 id="SQL-REVOKE-notes">
+ <refsect1 id="sql-revoke-notes">
 <!--==========================orignal english content==========================
   <title>Notes</title>
 ____________________________________________________________________________-->
@@ -367,7 +367,7 @@ ____________________________________________________________________________-->
   <para>
    A user can only revoke privileges that were granted directly by
    that user.  If, for example, user A has granted a privilege with
-   grant option to user B, and user B has in turned granted it to user
+   grant option to user B, and user B has in turn granted it to user
    C, then user A cannot revoke the privilege directly from C.
    Instead, user A could revoke the grant option from user B and use
    the <literal>CASCADE</literal> option so that the privilege is
@@ -478,7 +478,7 @@ ____________________________________________________________________________-->
    </para>
  </refsect1>
 
- <refsect1 id="SQL-REVOKE-examples">
+ <refsect1 id="sql-revoke-examples">
 <!--==========================orignal english content==========================
   <title>Examples</title>
 ____________________________________________________________________________-->
@@ -542,7 +542,7 @@ REVOKE admins FROM joe;
 </programlisting></para>
  </refsect1>
 
- <refsect1 id="SQL-REVOKE-compatibility">
+ <refsect1 id="sql-revoke-compatibility">
 <!--==========================orignal english content==========================
   <title>Compatibility</title>
 ____________________________________________________________________________-->


### PR DESCRIPTION
1. ref/refresh_materialized_view.sgml，ref/prepare_transaction.sgml ，ref/revoke.sgml 三个文件将英文原文中的</>补充相应tag.


2. ref/refresh_materialized_view.sgml翻译
调整内容：
row6：
	根据WinMerge比较结果，将
		"<refentry id="SQL-REFRESHMATERIALIZEDVIEW">"
		调整为小写
		”<refentry id="sql-refreshmaterializedview">“

Row62，63
	根据WinMerge比较结果，将
  		"contents of a materialized view.  The old contents are discarded.  If"
		调整为新内容
		"contents of a materialized view.  To execute this command you must be the
   		owner of the materialized view.  The old contents are discarded.  If“
row73 
	根据row62，63英文内容变化，将
		"物化视图的内容。旧的内容会被抛弃。如果指定了"
		调整为新翻译内容
		"物化视图的内容。你必须是该物化视图的属主才能执行这个命令.旧的内容会被抛弃。如果指定了"

row184
	根据WinMerge比较结果，将
		   "<xref linkend="SQL-CLUSTER">"
		调整为小写
		   <xref linkend="sql-cluster">
row192
	根据WinMerge比较结果，将
		"<xref linkend="SQL-CLUSTER"/>"
		调整为小写
		""<xref linkend="sql-cluster"/>


3. ref/prepare_transaction.sgml翻译
调整内容：
row6：
	根据WinMerge比较结果，将
		"<refentry id="SQL-PREPARE-TRANSACTION">"
		调整为小写
		"<refentry id="sql-prepare-transaction">"

row189:
	根据WinMerge比较结果，将
		"has executed any operations involving temporary tables,"
		调整为新内容
		" has executed any operations involving temporary tables or the session's"

row190:
	根据WinMerge比较结果，将
		"created any cursors <literal>WITH HOLD</>, or executed"
		调整为新内容
		"temporary namespace, created any cursors <literal>WITH HOLD</literal>, or"

row191
	根据WinMerge比较结果，将
		"<command>LISTEN</>, <command>UNLISTEN</>, or"
		调整为新内容
		"executed <command>LISTEN</command>, <command>UNLISTEN</command>, or"

row198
	根据row190，191英文原文变更，将
		"当前在已经执行过任何涉及到临时表、创建带"
		调整为新翻译内容
		"当前在已经执行过任何涉及到临时表或者会话的临时命名空间、创建带"