### PR TITLE
sgml/翻译11.2 release-11.sgml

### DIFF
--- a/postgresql/doc/src/sgml/release-11.sgml
+++ b/postgresql/doc/src/sgml/release-11.sgml
@@ -2,29 +2,54 @@
 <!-- See header comment in release.sgml about typical markup -->
 
  <sect1 id="release-11-2">
+<!--==========================orignal english content==========================
   <title>Release 11.2</title>
+____________________________________________________________________________-->
+  <title>版本11.2</title>
 
   <formalpara>
+<!--==========================orignal english content==========================
   <title>Release date:</title>
+____________________________________________________________________________-->
+  <title>发布日期:</title>
+<!--==========================orignal english content==========================
+  <para>2019-02-14</para>
+____________________________________________________________________________-->
   <para>2019-02-14</para>
   </formalpara>
 
+<!--==========================orignal english content==========================
   <para>
    This release contains a variety of fixes from 11.1.
    For information about new features in major release 11, see
    <xref linkend="release-11"/>.
   </para>
+____________________________________________________________________________-->
+  <para>
+   该版本包含一些自版本11.1以来的修补。关于主版本11的新特性的信息，见<xref linkend="release-11"/>。
+  </para>
 
   <sect2>
+<!--==========================orignal english content==========================
    <title>Migration to Version 11.2</title>
+____________________________________________________________________________-->
+   <title>迁移到版本11.2</title>
 
+<!--==========================orignal english content==========================
    <para>
     A dump/restore is not required for those running 11.X.
+   </para>
+____________________________________________________________________________-->
+   <para>
+    对于运行11.X的数据库，不需要转储/恢复。
    </para>
   </sect2>
 
   <sect2>
+<!--==========================orignal english content==========================
    <title>Changes</title>
+____________________________________________________________________________-->
+   <title>修改列表</title>
 
    <itemizedlist>
 
@@ -38,12 +63,18 @@ Branch: REL9_6_STABLE [b9cce9ddf] 2018-11-19 13:54:00 +1300
 Branch: REL9_5_STABLE [312435232] 2018-11-19 14:13:22 +1300
 Branch: REL9_4_STABLE [f1ff5f51d] 2018-11-19 14:26:28 +1300
 -->
+<!--==========================orignal english content==========================
      <para>
       By default, panic instead of retrying
       after <function>fsync()</function> failure, to avoid possible data
       corruption (Craig Ringer, Thomas Munro)
      </para>
+____________________________________________________________________________-->
+     <para>
+      缺省地，在<function>fsync()</function>失败后用panic代替重试，以避免可能的数据损坏。(Craig Ringer, Thomas Munro)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       Some popular operating systems discard kernel data buffers when
       unable to write them out, reporting this
@@ -55,13 +86,22 @@ Branch: REL9_4_STABLE [f1ff5f51d] 2018-11-19 14:26:28 +1300
       such a situation.  While this is surely ugly and inefficient, there
       are few alternatives, and fortunately the case happens very rarely.
      </para>
+____________________________________________________________________________-->
+     <para>
+      当不能将内核数据缓冲区写出来时，一些流行的操作系统会丢弃缓冲区的内容，将这报告为<function>fsync()</function>失败。如重新发出<function>fsync()</function>请求，会成功，但实际上数据已丢失，这样继续下去就会冒数据损坏的风险。相反通过出一次panic状况，我们可以从WAL重放，这其中可能包含该情形下仅余下的数据拷贝。这当然令人讨厌且效率低下，但几乎没有其他选择。所幸的是这种情况很少发生。
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       A new server parameter <xref linkend="guc-data-sync-retry"/>
       has been added to control this; if you are certain that your
       kernel does not discard dirty data buffers in such scenarios,
       you can set <varname>data_sync_retry</varname>
       to <literal>on</literal> to restore the old behavior.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      新增加的服务器参数<xref linkend="guc-data-sync-retry"/>用来控制此项设置；如果确定此情形下内核不丢弃脏数据缓冲区，可以设置<varname>data_sync_retry</varname>为<literal>on</literal>，以恢复过去的行为。
      </para>
     </listitem>
 
@@ -75,16 +115,25 @@ Branch: REL9_6_STABLE [60b1d6c2a] 2019-02-04 19:18:50 -0500
 Branch: REL9_5_STABLE [ed64db588] 2019-02-04 19:18:50 -0500
 Branch: REL9_4_STABLE [bb428cb11] 2019-02-04 19:18:50 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Include each major release branch's release notes in the
       documentation for only that branch, rather than that branch and all
       later ones (Tom Lane)
      </para>
+____________________________________________________________________________-->
+     <para>
+      在文档中只包含每个主要发行分支的发行注释，而不包括该分支和所有后续分支的发行注释 (Tom Lane)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       The duplication induced by the previous policy was getting out of
       hand.  Our plan is to provide a full archive of release notes on
       the project's web site, but not duplicate it within each release.
+     </para>
+____________________________________________________________________________-->
+     <para>      以前的策略导致的重复近乎失控。我们的计划是在项目的网站上提供发行注释的全部归档，但不在每次发布中重复。
      </para>
     </listitem>
 
@@ -94,13 +143,23 @@ Author: Alvaro Herrera <alvherre@alvh.no-ip.org>
 Branch: master [0ad41cf53] 2019-01-14 19:28:10 -0300
 Branch: REL_11_STABLE [74aa7e046] 2019-01-14 19:25:19 -0300
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix handling of unique indexes with <literal>INCLUDE</literal>
       columns on partitioned tables (&Aacute;lvaro Herrera)
      </para>
+____________________________________________________________________________-->
+     <para>
+      修复分区表上具有<literal>INCLUDE</literal>列的唯一索引的处理 (&Aacute;lvaro Herrera)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       The uniqueness condition was not checked properly in such cases.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      该情况没有适当地检查唯一性条件。
      </para>
     </listitem>
 
@@ -111,10 +170,15 @@ Branch: master [705d433fd] 2018-11-08 16:22:09 -0300
 Branch: REL_11_STABLE [e0c05bf4a] 2018-11-08 16:22:09 -0300
 Branch: REL_10_STABLE [21c9e4973] 2018-11-08 16:22:09 -0300
 -->
+<!--==========================orignal english content==========================
      <para>
       Ensure that <literal>NOT NULL</literal> constraints of a partitioned
       table are honored within its partitions
       (&Aacute;lvaro Herrera, Amit Langote)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      确保分区表的<literal>NOT NULL</literal>约束在其分区内得到遵守 (&Aacute;lvaro Herrera, Amit Langote)
      </para>
     </listitem>
 
@@ -128,17 +192,27 @@ Branch: REL_11_STABLE [71eba8399] 2019-01-24 11:18:35 -0300
 Branch: master [efd9366dc] 2019-01-24 14:09:56 -0300
 Branch: REL_11_STABLE [1ad521099] 2019-01-24 14:09:56 -0300
 -->
+<!--==========================orignal english content==========================
      <para>
       Update catalog state correctly for partition table constraints when
       detaching their partition (Amit Langote, &Aacute;lvaro Herrera)
      </para>
+____________________________________________________________________________-->
+     <para>
+      分离分区表时正确更新分区的表约束的目录状态 (Amit Langote, &Aacute;lvaro Herrera)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       Previously, the <structname>pg_constraint</structname>.<structfield>conislocal</structfield>
       field for such a constraint might improperly be left
       as <literal>false</literal>, rendering it undroppable.
       A dump/restore or pg_upgrade would cure the problem, but
       if necessary, the catalog field can be adjusted manually.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      以前，此类约束的<structname>pg_constraint</structname>.<structfield>conislocal</structfield>字段可能不正确地保留为<literal>false</literal>，从而使其不可删除。转储/恢复或pg_upgrade可以解决此问题，但如有需要，可以手动调整目录字段。
      </para>
     </listitem>
 
@@ -150,10 +224,15 @@ Branch: REL_11_STABLE [123cc697a] 2019-01-21 19:59:07 -0300
 Branch: master [cb90de1aa] 2019-02-10 10:00:11 -0300
 Branch: REL_11_STABLE [cc126b45e] 2019-02-10 10:00:11 -0300
 -->
+<!--==========================orignal english content==========================
      <para>
       Create or delete foreign key enforcement triggers correctly when
       attaching or detaching a partition in a partitioned table that
       has a foreign-key constraint (Amit Langote, &Aacute;lvaro Herrera)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      在具有外键约束的分区表中附加或分离分区时，正确地创建或删除强制触发器 (Amit Langote, &Aacute;lvaro Herrera)
      </para>
     </listitem>
 
@@ -163,9 +242,14 @@ Author: Alvaro Herrera <alvherre@alvh.no-ip.org>
 Branch: master [0325d7a59] 2019-01-18 15:00:45 -0300
 Branch: REL_11_STABLE [4dff8935f] 2019-01-18 14:57:49 -0300
 -->
+<!--==========================orignal english content==========================
      <para>
       Avoid useless creation of duplicate foreign key constraints
       in partitioned tables (&Aacute;lvaro Herrera)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      避免在分区表中无用地创建重复的外键约束 (&Aacute;lvaro Herrera)
      </para>
     </listitem>
 
@@ -175,14 +259,24 @@ Author: Alvaro Herrera <alvherre@alvh.no-ip.org>
 Branch: master [71a05b223] 2018-12-05 13:31:51 -0300
 Branch: REL_11_STABLE [37798a8e8] 2018-12-05 13:31:55 -0300
 -->
+<!--==========================orignal english content==========================
      <para>
       When an index is created on a partitioned table
       using <literal>ONLY</literal>, and there are no partitions yet, mark
       it valid immediately (&Aacute;lvaro Herrera)
      </para>
+____________________________________________________________________________-->
+     <para>
+      当在分区表上使用<literal>ONLY</literal>创建的索引还没有分区时，立即将其标记为有效 (&Aacute;lvaro Herrera)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       Otherwise there is no way to make it become valid.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      否则，无法让其生效。
      </para>
     </listitem>
 
@@ -195,14 +289,24 @@ Branch: REL_10_STABLE [1c142612c] 2018-12-20 16:42:13 -0300
 Branch: master [0c2377152] 2018-12-20 10:58:22 -0300
 Branch: REL_11_STABLE [9bb2ce5ec] 2018-12-20 11:11:13 -0300
 -->
+<!--==========================orignal english content==========================
      <para>
       Use a safe table lock level when detaching a partition
       (&Aacute;lvaro Herrera)
      </para>
+____________________________________________________________________________-->
+     <para>
+      分离分区时，使用安全的表锁级别 (&Aacute;lvaro Herrera)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       The previous locking level was too weak and might allow
       concurrent DDL on the table, with bad results.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      以前的表锁级别太弱，可能允许表上并发执行DDL，产生坏结果。
      </para>
     </listitem>
 
@@ -213,10 +317,15 @@ Branch: master [319a81018] 2018-11-09 10:03:22 +0900
 Branch: REL_11_STABLE [84b4a0cf6] 2018-11-09 10:03:31 +0900
 Branch: REL_10_STABLE [52ea6a820] 2018-11-09 10:03:39 +0900
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix problems with applying <literal>ON COMMIT DROP</literal>
       and <literal>ON COMMIT DELETE ROWS</literal> to partitioned tables
       and tables with inheritance children (Michael Paquier)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      修复对分区表和具有继承孩子的表应用<literal>ON COMMIT DROP</literal>和<literal>ON COMMIT DELETE ROWS</literal>的问题 (Michael Paquier)
      </para>
     </listitem>
 
@@ -227,14 +336,24 @@ Branch: master [5c9a5513a] 2018-11-19 11:16:28 -0300
 Branch: REL_11_STABLE [a4db7fe0f] 2018-11-19 11:16:28 -0300
 Branch: REL_10_STABLE [85efd1a04] 2018-11-19 11:16:28 -0300
 -->
+<!--==========================orignal english content==========================
      <para>
       Disallow <command>COPY FREEZE</command> on partitioned tables
       (David Rowley)
      </para>
+____________________________________________________________________________-->
+     <para>
+      分区表上不允许<command>COPY FREEZE</command> (David Rowley)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       This should eventually be made to work, but it may require a patch
       that's too complicated to risk back-patching.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      这最终应该能起作用，但需要一个非常复杂的补丁，可能有回补的风险。
      </para>
     </listitem>
 
@@ -245,12 +364,17 @@ Branch: master [171e0418b] 2019-02-06 01:09:32 -0800
 Branch: REL_11_STABLE [297d627e0] 2019-02-06 01:09:42 -0800
 Branch: REL_11_STABLE [920311ab1] 2019-02-09 02:44:10 -0800
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix possible index corruption when the indexed column has
       a <quote>fast default</quote> (that is, it was added
       by <literal>ALTER TABLE ADD COLUMN</literal> with a constant non-NULL
       default value specified, after the table already contained some rows)
       (Andres Freund)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      修复索引列具有“快速默认值”(也就是说，表中已有一些行之后，又通过<literal>ALTER TABLE ADD COLUMN</literal>，以指定缺省值来增加行)时可能出现的索引损坏 Andres Freund)
      </para>
     </listitem>
 
@@ -262,10 +386,15 @@ Branch: REL_11_STABLE [076ffbcb5] 2019-01-10 16:24:57 -0500
 Branch: master [e33884d41] 2019-01-11 17:12:54 -0500
 Branch: REL_11_STABLE [89d52b9a3] 2019-01-11 17:16:43 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Correctly adjust <quote>fast default</quote> values
       during <command>ALTER TABLE ... ALTER COLUMN TYPE</command>
       (Andrew Dunstan)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      在<command>ALTER TABLE ... ALTER COLUMN TYPE</command>时，正确调整“快速默认值” (Andrew Dunstan)
      </para>
     </listitem>
 
@@ -279,9 +408,14 @@ Branch: REL9_6_STABLE [073afae81] 2019-02-02 08:54:33 +0530
 Branch: REL9_5_STABLE [6a2c9c633] 2019-02-02 09:16:35 +0530
 Branch: REL9_4_STABLE [fba0a8292] 2019-02-02 15:43:58 +0530
 -->
+<!--==========================orignal english content==========================
      <para>
       Avoid possible deadlock when acquiring multiple buffer locks
       (Nishant Fnu)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      获取多个缓冲区锁时避免可能的死锁 (Nishant Fnu)
      </para>
     </listitem>
 
@@ -292,17 +426,27 @@ Branch: master [fd83c83d0] 2018-12-13 06:55:34 +0300
 Branch: REL_11_STABLE [9aa94d853] 2018-12-13 06:15:23 +0300
 Branch: REL_10_STABLE [2e3bd064e] 2018-12-13 06:22:39 +0300
 -->
+<!--==========================orignal english content==========================
      <para>
       Avoid deadlock between GIN vacuuming and concurrent index insertions
       (Alexander Korotkov, Andrey Borodin, Peter Geoghegan)
      </para>
+____________________________________________________________________________-->
+     <para>
+      避免GIN清理和并发索引插入之间死锁 (Alexander Korotkov, Andrey Borodin, Peter Geoghegan)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       This change partially reverts a performance improvement, introduced
       in version 10.0, that attempted to reduce the number of index pages
       locked during deletion of a GIN posting tree page.  That's now been
       found to lead to deadlocks, so we've removed it pending closer
       analysis.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      此更改部分恢复了版本10.0中引入的性能改进，该改进尝试减少删除GIN posting树页面期间锁定的索引页数。现在已经发现这会导致死锁，所以我们在进一步分析之前将之移除。
      </para>
     </listitem>
 
@@ -317,9 +461,14 @@ Branch: REL9_5_STABLE [f6c44e1b5] 2018-12-13 06:31:16 +0300
 Branch: REL9_4_STABLE [19cf52e6c] 2018-12-13 06:36:54 +0300
 Branch: REL9_4_STABLE [bf0e5a73b] 2018-12-13 22:32:05 +0300
 -->
+<!--==========================orignal english content==========================
      <para>
       Avoid deadlock between hot-standby queries and replay of GIN index
       page deletion (Alexander Korotkov)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      避免热备份查询与GIN索引页删除重放间的死锁 (Alexander Korotkov)
      </para>
     </listitem>
 
@@ -333,9 +482,14 @@ Branch: REL9_6_STABLE [650296f8f] 2019-01-30 11:02:47 +0100
 Branch: REL9_5_STABLE [edd8278c5] 2019-01-30 11:16:27 +0100
 Branch: REL9_4_STABLE [452253eae] 2019-01-30 11:17:05 +0100
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix possible crashes in logical replication when index expressions
       or predicates are in use (Peter Eisentraut)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      修复索引表达式或谓词在使用时逻辑复制可能的崩溃 (Peter Eisentraut)
      </para>
     </listitem>
 
@@ -349,9 +503,14 @@ Branch: REL9_6_STABLE [b86d148ae] 2018-11-28 01:44:31 +0100
 Branch: REL9_5_STABLE [77d2815e4] 2018-11-28 01:44:43 +0100
 Branch: REL9_4_STABLE [c1a5caea8] 2018-11-28 01:53:29 +0100
 -->
+<!--==========================orignal english content==========================
      <para>
       Avoid useless and expensive logical decoding of TOAST data during a
       table rewrite (Tomas Vondra)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      避免表重写期间对TOAST数据进行无用的、高代价的逻辑解码 (Tomas Vondra)
      </para>
     </listitem>
 
@@ -365,9 +524,14 @@ Branch: REL9_6_STABLE [8340eba6d] 2018-11-29 09:12:53 +0900
 Branch: REL9_5_STABLE [b9bdbf8c1] 2018-11-29 09:12:57 +0900
 Branch: REL9_4_STABLE [b81d08d60] 2018-11-29 09:13:04 +0900
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix logic for stopping a subset of WAL senders when synchronous
       replication is enabled (Paul Guo, Michael Paquier)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      修复同步复制启用时停止WAL发送器子集的逻辑 (Paul Guo, Michael Paquier)
      </para>
     </listitem>
 
@@ -381,9 +545,14 @@ Branch: REL9_6_STABLE [014763e97] 2019-02-01 10:35:52 +0900
 Branch: REL9_5_STABLE [90f1ba7ec] 2019-02-01 10:35:58 +0900
 Branch: REL9_4_STABLE [05d24cf7c] 2019-02-01 10:36:02 +0900
 -->
+<!--==========================orignal english content==========================
      <para>
       Avoid possibly writing an incorrect replica identity field in a
       tuple deletion WAL record (Stas Kelvich)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      避免在删除元组的WAL记录中写入不正确的副本标识字段 (Stas Kelvich)
      </para>
     </listitem>
 
@@ -394,10 +563,15 @@ Branch: master [bf491a907] 2018-12-23 16:42:22 +0900
 Branch: REL_11_STABLE [ff9c22266] 2018-12-23 16:43:47 +0900
 Branch: REL_10_STABLE [15f69279e] 2018-12-23 16:43:56 +0900
 -->
+<!--==========================orignal english content==========================
      <para>
       Prevent incorrect use of WAL-skipping optimization
       during <command>COPY</command> to a view or foreign table
       (Amit Langote, Michael Paquier)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      防止在<command>COPY</command>到视图或外部表期间错误地使用WAL跳过优化 (Amit Langote, Michael Paquier)
      </para>
     </listitem>
 
@@ -410,9 +584,14 @@ Branch: REL_10_STABLE [085757577] 2018-12-24 20:25:57 +0900
 Branch: REL9_6_STABLE [937870124] 2018-12-24 20:26:11 +0900
 Branch: REL9_5_STABLE [37126251a] 2018-12-24 20:26:20 +0900
 -->
+<!--==========================orignal english content==========================
      <para>
       Make the archiver prioritize WAL history files over WAL data files
       while choosing which file to archive next (David Steele)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      在选择哪些文件要归档时，使归档器优先归档WAL历史文件，而后才是WAL数据文件 (David Steele)
      </para>
     </listitem>
 
@@ -425,10 +604,15 @@ Branch: REL_10_STABLE [f9f63ed1f] 2018-12-12 13:49:41 -0500
 Branch: REL9_6_STABLE [10bad8c0f] 2018-12-12 13:49:42 -0500
 Branch: REL9_5_STABLE [6548d62a9] 2018-12-12 13:49:42 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix possible crash in <command>UPDATE</command> with a
       multiple <literal>SET</literal> clause using a
       sub-<literal>SELECT</literal> as source (Tom Lane)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      修复使用sub-<literal>SELECT</literal>作为源、有多个<literal>SET</literal>子句的<command>UPDATE</command>可能出现的崩溃 (Tom Lane)
      </para>
     </listitem>
 
@@ -438,10 +622,15 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
 Branch: master [eba2ce171] 2018-11-22 15:14:01 -0500
 Branch: REL_11_STABLE [595220a3a] 2018-11-22 15:14:01 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix crash when zero rows are fed
       to <function>json[b]_populate_recordset()</function>
       or <function>json[b]_to_recordset()</function> (Tom Lane)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      修复只有零行输入到<function>json[b]_populate_recordset()</function>或<function>json[b]_to_recordset()</function>时的崩溃 (Tom Lane)
      </para>
     </listitem>
 
@@ -455,9 +644,14 @@ Branch: REL9_6_STABLE [ef922faea] 2019-02-08 13:31:09 -0500
 Branch: REL9_5_STABLE [7821a4d60] 2019-02-08 13:31:15 -0500
 Branch: REL9_4_STABLE [37f3a7751] 2019-02-08 13:31:23 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Avoid crash if <application>libxml2</application> returns a null
       error message (Sergio Conde G&oacute;mez)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      避免<application>libxml2</application>返回空错误信息时的崩溃 (Sergio Conde G&oacute;mez)
      </para>
     </listitem>
 
@@ -467,9 +661,14 @@ Author: Andres Freund <andres@anarazel.de>
 Branch: master [b23852766] 2018-11-27 10:07:03 -0800
 Branch: REL_11_STABLE [aee085bc0] 2018-11-27 10:07:43 -0800
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix incorrect JIT tuple deforming code for tables with
       many columns (more than approximately 800) (Andres Freund)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      修复具有许多列（大约超过800）的表的不正确JIT元组变形代码 (Andres Freund)
      </para>
     </listitem>
 
@@ -485,9 +684,14 @@ Branch: REL_11_STABLE [6455c6588] 2019-02-09 01:05:50 -0800
 Branch: master [356687bd8] 2019-02-09 01:05:49 -0800
 Branch: REL_11_STABLE [35afccaba] 2019-02-09 01:05:50 -0800
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix performance and memory leakage issues in hash-based grouping
       (Andres Freund)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      修复基于哈希的分组中性能和内存泄漏问题 (Andres Freund)
      </para>
     </listitem>
 
@@ -501,15 +705,25 @@ Branch: REL9_6_STABLE [624046abe] 2019-01-17 06:26:15 +0000
 Branch: REL9_5_STABLE [91448e7dc] 2019-01-17 06:29:43 +0000
 Branch: REL9_4_STABLE [174fab993] 2019-01-17 06:35:31 +0000
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix spurious grouping-related parser errors caused by inconsistent
       handling of collation assignment (Andrew Gierth)
      </para>
+____________________________________________________________________________-->
+     <para>
+      修复由于排序规则分配的处理不一致而导致的与分组相关的错误 (Andrew Gierth)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       In some cases, expressions that should be considered to match
       were not seen as matching, if they included operations on collatable
       data types.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      在某些情况下，如果表达式包括可排序数据类型上的操作，认为应当匹配的表达式不见得就匹配。
      </para>
     </listitem>
 
@@ -519,9 +733,14 @@ Author: Peter Eisentraut <peter@eisentraut.org>
 Branch: master [cd5afd817] 2019-02-07 08:25:47 +0100
 Branch: REL_11_STABLE [004f494b5] 2019-02-07 08:25:54 +0100
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix parsing of collation-sensitive expressions in the arguments of
       a <command>CALL</command> statement (Peter Eisentraut)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      修复<command>CALL</command>语句参数中排序规则敏感的表达式的分析处理 (Peter Eisentraut)
      </para>
     </listitem>
 
@@ -531,9 +750,14 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
 Branch: master [f26c06a40] 2018-11-09 22:04:14 -0500
 Branch: REL_11_STABLE [8e02ee788] 2018-11-09 22:04:14 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Ensure proper cleanup after detecting an error in the argument list
       of a <command>CALL</command> statement (Tom Lane)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      检测到<command>CALL</command>语句的参数列表中有错误后，确保正确清除 (Tom Lane)
      </para>
     </listitem>
 
@@ -547,16 +771,26 @@ Branch: REL9_6_STABLE [c27c3993e] 2019-01-02 16:33:48 -0500
 Branch: REL9_5_STABLE [f8b9b8097] 2019-01-02 16:33:48 -0500
 Branch: REL9_4_STABLE [d6b37cdb6] 2019-01-02 16:33:48 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Check whether the comparison function
       underlying <function>LEAST()</function>
       or <function>GREATEST()</function> is leakproof, rather than just
       assuming it is (Tom Lane)
      </para>
+____________________________________________________________________________-->
+     <para>
+      检查<function>LEAST()</function>或<function>GREATEST()</function>下面的比较函数是否防泄漏，而不是假设它就是 (Tom Lane)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       Actual information leaks from btree comparison functions are
       typically hard to provoke, but in principle they could happen.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      由btree比较函数引起的实际信息泄漏通常很难发生，但原则上它们可能发生。
      </para>
     </listitem>
 
@@ -568,14 +802,24 @@ Branch: REL_11_STABLE [05eb923ea] 2019-01-11 15:54:08 -0500
 Branch: REL_10_STABLE [2977a312d] 2019-01-11 15:54:09 -0500
 Branch: REL9_6_STABLE [4f8097499] 2019-01-11 15:53:34 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix incorrect planning of queries involving nested loops both above
       and below a Gather plan node (Tom Lane)
      </para>
+____________________________________________________________________________-->
+     <para>
+      修复在Gather计划节点上方和下方涉及嵌套循环的查询的不正确规划 (Tom Lane)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       If both levels of nestloop needed to pass the same variable into
       their right-hand sides, an incorrect plan would be generated.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      如果嵌套循环的两层都要将同样的变量传到右侧，就会产生错误的计划。
      </para>
     </listitem>
 
@@ -589,9 +833,14 @@ Branch: REL9_6_STABLE [d468da0d6] 2019-02-07 13:11:16 -0500
 Branch: REL9_5_STABLE [1eeee6909] 2019-02-07 13:11:17 -0500
 Branch: REL9_4_STABLE [876fd37fc] 2019-02-07 13:10:46 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix incorrect planning of queries in which a lateral reference must
       be evaluated at a foreign table scan (Tom Lane)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      修复外部表扫描时必须评估横向引用的查询的错误计划 (Tom Lane)
      </para>
     </listitem>
 
@@ -601,10 +850,15 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
 Branch: master [6bdc3005b] 2019-02-10 22:51:32 -0500
 Branch: REL_11_STABLE [eb68d71f9] 2019-02-10 22:51:33 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix planner failure when the first column of a row comparison
       matches an index column, but later column(s) do not, and the index
       has included (non-key) columns (Tom Lane)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      修复行比较的第一列匹配索引列，但后面并不匹配且索引包含（非键）列时的查询器故障 (Tom Lane)
      </para>
     </listitem>
 
@@ -618,14 +872,24 @@ Branch: REL9_6_STABLE [7c2bc40b8] 2018-12-18 11:19:39 -0500
 Branch: REL9_5_STABLE [72a626e68] 2018-12-18 11:19:39 -0500
 Branch: REL9_4_STABLE [ef673a32d] 2018-12-18 11:19:39 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix corner-case underestimation of the cost of a merge join (Tom Lane)
      </para>
+____________________________________________________________________________-->
+     <para>
+      修复极端情况下归并连接成本的低估 (Tom Lane)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       The planner could prefer a merge join when the outer key range is
       much smaller than the inner key range, even if there are so many
       duplicate keys on the inner side that this is a poor choice.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      当外部键范围比内部键范围小得多时，计划器可能更偏向归并连接，即使内部有太多重复键，这是一种糟糕的选择。
      </para>
     </listitem>
 
@@ -639,9 +903,14 @@ Branch: REL9_6_STABLE [fe66fc6f9] 2018-11-12 11:19:04 -0500
 Branch: REL9_5_STABLE [92dbbe90c] 2018-11-12 11:19:04 -0500
 Branch: REL9_4_STABLE [2abc87953] 2018-11-12 11:19:04 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Avoid O(N^2) planning time growth when a query contains many
       thousand indexable clauses (Tom Lane)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      当查询包含数千条索引子句时，避免O(N^2)的计划时间增长 (Tom Lane)
      </para>
     </listitem>
 
@@ -651,9 +920,14 @@ Author: Etsuro Fujita <efujita@postgresql.org>
 Branch: master [8d8dcead1] 2019-01-21 17:12:40 +0900
 Branch: REL_11_STABLE [b10e3bba8] 2019-01-21 17:46:15 +0900
 -->
+<!--==========================orignal english content==========================
      <para>
       Improve planning speed for large inheritance or partitioning table
       groups (Amit Langote, Etsuro Fujita)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      提高大型继承或分区表组的规划速度 (Amit Langote, Etsuro Fujita)
      </para>
     </listitem>
 
@@ -667,17 +941,27 @@ Branch: REL9_6_STABLE [60de80cd2] 2019-01-03 17:00:08 -0500
 Branch: REL9_5_STABLE [d2557c42a] 2019-01-03 17:00:08 -0500
 Branch: REL9_4_STABLE [3010de813] 2019-01-03 17:00:08 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Improve <command>ANALYZE</command>'s handling of
       concurrently-updated rows (Jeff Janes, Tom Lane)
      </para>
+____________________________________________________________________________-->
+     <para>
+      改进并发更新行的<command>ANALYZE</command>处理 (Jeff Janes, Tom Lane)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       Previously, rows deleted by an in-progress transaction were omitted
       from <command>ANALYZE</command>'s sample, but this has been found to
       lead to more inconsistency than including them would do.  In effect,
       the sample now corresponds to an MVCC snapshot as
       of <command>ANALYZE</command>'s start time.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      以前，由正在进行的事务删除的行在<command>ANALYZE</command>样本中是被忽略的，但这会导致比包含它们有更大的不一致性。实际上，现在采样对应于<command>ANALYZE</command>开始时的MVCC快照。
      </para>
     </listitem>
 
@@ -691,15 +975,26 @@ Branch: REL9_6_STABLE [285abc8df] 2018-12-27 10:17:21 +0900
 Branch: REL9_5_STABLE [0a323ae67] 2018-12-27 10:17:26 +0900
 Branch: REL9_4_STABLE [1d7007671] 2018-12-27 10:17:42 +0900
 -->
+<!--==========================orignal english content==========================
      <para>
       Make <command>TRUNCATE</command> ignore inheritance child tables
       that are temporary tables of other sessions (Amit Langote, Michael
       Paquier)
      </para>
+____________________________________________________________________________-->
+     <para>
+      使<command>TRUNCATE</command>忽略作为其他会话的临时表的继承子表 (Amit Langote, Michael
+      Paquier)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       This brings <command>TRUNCATE</command> into line with the behavior
       of other commands.  Previously, such cases usually ended in failure.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      这使<command>TRUNCATE</command>与其他命令的行为保持一致。以前这种情况通常是最终失败。
      </para>
     </listitem>
 
@@ -712,14 +1007,24 @@ Branch: REL_10_STABLE [54f24ab76] 2018-12-07 12:12:00 -0500
 Branch: REL9_6_STABLE [078303f79] 2018-12-07 12:12:00 -0500
 Branch: REL9_5_STABLE [4d5cfb911] 2018-12-07 12:12:00 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix <command>TRUNCATE</command> to update the statistics counters
       for the right table (Tom Lane)
      </para>
+____________________________________________________________________________-->
+     <para>
+      修复<command>TRUNCATE</command>以更新适当表的统计计数器 (Tom Lane)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       If the truncated table had a TOAST table, that table's counters were
       reset instead.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      如果被截断的表有TOAST表，则该表计数器将被重置。
      </para>
     </listitem>
 
@@ -731,9 +1036,14 @@ Branch: REL_11_STABLE [128ce8e1a] 2018-12-19 19:40:25 -0500
 Branch: REL_10_STABLE [9e6cd794c] 2018-12-19 19:41:06 -0500
 Branch: REL9_6_STABLE [5668afeb6] 2018-12-19 19:41:18 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Process <command>ALTER TABLE ONLY ADD COLUMN IF NOT EXISTS</command>
       correctly (Greg Stark)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      正确处理<command>ALTER TABLE ONLY ADD COLUMN IF NOT EXISTS</command> (Greg Stark)
      </para>
     </listitem>
 
@@ -747,15 +1057,25 @@ Branch: REL9_6_STABLE [0d5b27351] 2019-01-25 21:14:31 -0500
 Branch: REL9_5_STABLE [741ee4890] 2019-01-25 21:14:31 -0500
 Branch: REL9_4_STABLE [549d2a238] 2019-01-25 21:14:31 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Allow <command>UNLISTEN</command> in hot-standby mode
       (Shay Rojansky)
      </para>
+____________________________________________________________________________-->
+     <para>
+      允许在热备模式下<command>UNLISTEN</command> (Shay Rojansky)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       This is necessarily a no-op, because <command>LISTEN</command>
       isn't allowed in hot-standby mode; but allowing the dummy operation
       simplifies session-state-reset logic in clients.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      这必然是一个no-op，因为热备模式下不允许<command>LISTEN</command>；但允许虚操作简化客户端中的会话状态重置逻辑。
      </para>
     </listitem>
 
@@ -769,16 +1089,26 @@ Branch: REL9_6_STABLE [d431dff1a] 2018-11-09 20:42:03 -0500
 Branch: REL9_5_STABLE [47088c599] 2018-11-09 20:42:03 -0500
 Branch: REL9_4_STABLE [277602dfe] 2018-11-09 20:42:03 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix missing role dependencies in some schema and data type
       permissions lists (Tom Lane)
      </para>
+____________________________________________________________________________-->
+     <para>
+      修复一些模式和数据类型权限列表中缺少的角色依赖 (Tom Lane)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       In some cases it was possible to drop a role to which permissions
       had been granted.  This caused no immediate problem, but a
       subsequent dump/reload or upgrade would fail, with symptoms
       involving attempts to grant privileges to all-numeric role names.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      有些情况下可以删除已授予权限的角色。这不会立刻有问题，但是后来的转储/重载或升级失败，会出现尝试给全数字角色名授予权限的症状。
      </para>
     </listitem>
 
@@ -789,15 +1119,25 @@ Branch: master [c5660e0aa] 2019-01-18 09:21:44 +0900
 Branch: REL_11_STABLE [3e4fdb3bc] 2019-01-18 09:21:52 +0900
 Branch: REL_10_STABLE [b15160bc7] 2019-01-18 09:21:58 +0900
 -->
+<!--==========================orignal english content==========================
      <para>
       Prevent use of a session's temporary schema within a two-phase
       transaction (Michael Paquier)
      </para>
+____________________________________________________________________________-->
+     <para>
+      防止在两阶段事务中使用会话的临时模式 (Michael Paquier)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       Accessing a temporary table within such a transaction has been
       forbidden for a long time, but it was still possible to cause
       problems with other operations on temporary objects.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      访问此类事务中的临时表已被禁止了很长时间，但仍有可能导致在临时对象上其他操作的问题。
      </para>
     </listitem>
 
@@ -809,14 +1149,24 @@ Branch: REL_11_STABLE [a7474308c] 2019-01-21 19:34:11 -0300
 Branch: REL_10_STABLE [3037b28b8] 2019-01-21 19:34:11 -0300
 Branch: REL9_6_STABLE [4aead13a7] 2019-01-21 19:34:11 -0300
 -->
+<!--==========================orignal english content==========================
      <para>
       Ensure relation caches are updated properly after adding or removing
       foreign key constraints (&Aacute;lvaro Herrera)
      </para>
+____________________________________________________________________________-->
+     <para>
+      确保添加或删除外键约束后关系缓存适当地更新 (&Aacute;lvaro Herrera)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       This oversight could result in existing sessions failing to enforce
       a newly-created constraint, or continuing to enforce a dropped one.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      该疏忽会导致已有会话执行新建约束失败或继续执行已删除的约束。
      </para>
     </listitem>
 
@@ -836,9 +1186,14 @@ Branch: REL9_6_STABLE [419bd6371] 2018-12-17 12:43:57 +0900
 Branch: REL9_5_STABLE [c7567e09d] 2018-12-17 12:44:02 +0900
 Branch: REL9_4_STABLE [696c68c2b] 2018-12-17 12:44:09 +0900
 -->
+<!--==========================orignal english content==========================
      <para>
       Ensure relation caches are updated properly after renaming
       constraints (Amit Langote)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      确保重命名约束后关系缓存适当地更新 (Amit Langote)
      </para>
     </listitem>
 
@@ -850,9 +1205,15 @@ Branch: REL_11_STABLE [8193d6407] 2018-12-21 02:37:31 +0300
 Branch: REL_10_STABLE [e36e25275] 2018-12-21 02:33:48 +0300
 Branch: REL9_6_STABLE [1b0280745] 2018-12-21 02:33:37 +0300
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix replay of GiST index micro-vacuum operations so that concurrent
       hot-standby queries do not see inconsistent state (Alexander
+      Korotkov)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      修复GiST索引微清理操作的重放，这样并发热备查询不会看到不一致的状态 (Alexander
       Korotkov)
      </para>
     </listitem>
@@ -867,10 +1228,15 @@ Branch: REL9_6_STABLE [cd24b4eae] 2018-12-13 06:47:38 +0300
 Branch: REL9_5_STABLE [ad6ebcfcb] 2018-12-13 06:52:33 +0300
 Branch: REL9_4_STABLE [1cf175c74] 2018-12-13 06:52:26 +0300
 -->
+<!--==========================orignal english content==========================
      <para>
       Prevent empty GIN index pages from being reclaimed too quickly,
       causing failures of concurrent searches
       (Andrey Borodin, Alexander Korotkov)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      防止空GIN索引页回收得太快，导致并发搜索失败 (Andrey Borodin, Alexander Korotkov)
      </para>
     </listitem>
 
@@ -890,16 +1256,26 @@ Branch: REL9_6_STABLE [1f99d0867] 2018-11-24 13:53:12 -0500
 Branch: REL9_5_STABLE [298510cae] 2018-11-24 13:53:12 -0500
 Branch: REL9_4_STABLE [bf9fb00dd] 2018-11-24 13:53:12 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix edge-case failures in float-to-integer coercions (Andrew
       Gierth, Tom Lane)
      </para>
+____________________________________________________________________________-->
+     <para>
+      修复极端情况下浮点数到整数强制转换的失败 (Andrew Gierth, Tom Lane)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       Values very slightly above the maximum valid integer value might not
       be rejected, and then would overflow, producing the minimum valid
       integer instead.  Also, values that should round to the minimum or
       maximum integer value might be incorrectly rejected.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      比最大有效整数值大一点点的值可能不会被拒绝，然后会溢出，反而产生最小的有效整数。此外，应舍入最小或最大整数值的值可能被错误地拒绝。
      </para>
     </listitem>
 
@@ -909,10 +1285,15 @@ Author: Thomas Munro <tmunro@postgresql.org>
 Branch: master [257ef3cd4] 2018-11-13 17:46:28 +1300
 Branch: REL_11_STABLE [6b6c64a96] 2018-11-13 17:47:00 +1300
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix parsing of space-separated lists of host names in
       the <varname>ldapserver</varname> parameter of LDAP authentication
       entries in <filename>pg_hba.conf</filename> (Thomas Munro)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      修复<filename>pg_hba.conf</filename>中LDAP认证入口的<varname>ldapserver</varname>参数内由空格分隔的主机名列表的处理 (Thomas Munro)
      </para>
     </listitem>
 
@@ -924,15 +1305,25 @@ Branch: REL_11_STABLE [0640d9517] 2018-11-28 14:14:40 +1300
 Branch: REL_10_STABLE [96ed0b870] 2018-11-28 14:15:00 +1300
 Branch: REL9_6_STABLE [63d835066] 2018-11-28 14:20:07 +1300
 -->
+<!--==========================orignal english content==========================
      <para>
       When making a PAM authentication request, don't set
       the <varname>PAM_RHOST</varname> variable if the connection is via
       a Unix socket (Thomas Munro)
      </para>
+____________________________________________________________________________-->
+     <para>
+      进行PAM认证请求时，如果是通过Unix套接字连接，则不要设置<varname>PAM_RHOST</varname>变量 (Thomas Munro)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       Previously that variable would be set to <literal>[local]</literal>,
       which is at best unhelpful, since it's supposed to be a host name.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      以前，该变量设置为<literal>[local]</literal>，这其实没什么用，因为它应为主机名。
      </para>
     </listitem>
 
@@ -946,11 +1337,17 @@ Branch: REL9_6_STABLE [041ad9a66] 2018-11-08 17:33:26 -0500
 Branch: REL9_5_STABLE [88275ac19] 2018-11-08 17:33:26 -0500
 Branch: REL9_4_STABLE [2407d4807] 2018-11-08 17:33:26 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Disallow setting <varname>client_min_messages</varname> higher
       than <literal>ERROR</literal> (Jonah Harris, Tom Lane)
      </para>
+____________________________________________________________________________-->
+     <para>
+      不允许设置<varname>client_min_messages</varname>的值高于<literal>ERROR</literal> (Jonah Harris, Tom Lane)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       Previously, it was possible to set this variable
       to <literal>FATAL</literal> or <literal>PANIC</literal>, which had
@@ -961,6 +1358,10 @@ Branch: REL9_4_STABLE [2407d4807] 2018-11-08 17:33:26 -0500
       In released branches, fix this by silently treating such settings as
       meaning <literal>ERROR</literal> instead.  Version 12 and later will
       reject those alternatives altogether.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      以前，可以将此变量设置为<literal>FATAL</literal>或<literal>PANIC</literal>，这会抑制向客户端传输一般错误消息。但是，这与<productname>PostgreSQL</productname>有线协议规范中给出的保证相违背，导致一些客户端变得非常混乱。在已发布的分支中，通过将这些设置默认为有意义的<literal>ERROR</literal>来解决此问题。版本12和以后的版本完全不会考虑这些替代方案。
      </para>
     </listitem>
 
@@ -981,17 +1382,27 @@ Branch: REL9_6_STABLE [1d334ab6e] 2019-01-23 22:47:13 -0500
 Branch: REL9_5_STABLE [7ac0e71aa] 2019-01-23 22:47:18 -0500
 Branch: REL9_4_STABLE [773f59440] 2019-01-23 22:47:23 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix <application>ecpglib</application> to
       use <function>uselocale()</function>
       or <function>_configthreadlocale()</function> in preference
       to <function>setlocale()</function> (Michael Meskes, Tom Lane)
      </para>
+____________________________________________________________________________-->
+     <para>
+      修复<application>ecpglib</application>，优先使用<function>uselocale()</function>或<function>_configthreadlocale()</function>，而后才是<function>setlocale()</function> (Michael Meskes, Tom Lane)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       Since <function>setlocale()</function> is not thread-local, and
       might not even be thread-safe, the previous coding caused problems
       in multi-threaded <application>ecpg</application> applications.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      由于<function>setlocale()</function>不是线程局部的，甚至可能不是线程安全的，所以导致以前的编码在多线程<application>ecpg</application>应用程序中出了问题。
      </para>
     </listitem>
 
@@ -1011,14 +1422,25 @@ Branch: REL9_6_STABLE [f9e25ba14] 2018-11-14 11:27:31 -0500
 Branch: REL9_5_STABLE [68f30638a] 2018-11-14 11:27:31 -0500
 Branch: REL9_4_STABLE [41609776f] 2018-11-14 11:27:31 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix incorrect results for numeric data passed through
       an <application>ecpg</application> <acronym>SQLDA</acronym>
       (SQL Descriptor Area) (Daisuke Higuchi)
      </para>
+____________________________________________________________________________-->
+     <para>
+      修复通过<application>ecpg</application> <acronym>SQLDA</acronym>
+      (SQL描述符区域)传数值数据的错误结果 (Daisuke Higuchi)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       Values with leading zeroes were not copied correctly.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      带前导零的值未正确复制。
      </para>
     </listitem>
 
@@ -1031,17 +1453,28 @@ Branch: REL_10_STABLE [8e97a97b3] 2019-01-26 14:15:42 -0500
 Branch: REL9_6_STABLE [ae4c7d5ab] 2019-01-26 14:15:42 -0500
 Branch: REL9_5_STABLE [cda1e27fb] 2019-01-26 14:15:42 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix <application>psql</application>'s <command>\g</command>
       <replaceable>target</replaceable> meta-command to work
       with <command>COPY TO STDOUT</command>
       (Daniel V&eacute;rit&eacute;)
      </para>
+____________________________________________________________________________-->
+     <para>
+      修复<application>psql</application>的<command>\g</command>
+      <replaceable>target</replaceable>元命令以使用<command>COPY TO STDOUT</command> (Daniel V&eacute;rit&eacute;)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       Previously, the <replaceable>target</replaceable> option was
       ignored, so that the copy data always went to the current query
       output target.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      以前忽略了<replaceable>target</replaceable>选项，因此拷贝的数据总是跑到当前查询输出目标那里。
      </para>
     </listitem>
 
@@ -1055,15 +1488,25 @@ Branch: REL9_6_STABLE [ac305ff8c] 2018-11-26 17:32:51 -0500
 Branch: REL9_5_STABLE [18a0a8548] 2018-11-26 17:32:51 -0500
 Branch: REL9_4_STABLE [74bfb5388] 2018-11-26 17:32:51 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Make <application>psql</application>'s LaTeX output formats render
       special characters properly (Tom Lane)
      </para>
+____________________________________________________________________________-->
+     <para>
+      使<application>psql</application>的LaTeX输出格式正确地呈现特殊字符 (Tom Lane)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       Backslash and some other ASCII punctuation characters were not
       rendered correctly, leading to document syntax errors or wrong
       characters in the output.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      反斜杠和其他一些ASCII标点符号未能正确呈现，导致文档语法错误或输出中出现错误字符。
      </para>
     </listitem>
 
@@ -1073,17 +1516,27 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
 Branch: master [e6c3ba7fb] 2019-01-24 11:31:54 -0500
 Branch: REL_11_STABLE [27d6bc68f] 2019-01-24 11:31:54 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Make <application>pgbench</application>'s random number generation
       fully deterministic and platform-independent
-      when <option>--random-seed=<replaceable>N</replaceable></option> is
+      when <option>-&minus;random-seed=<replaceable>N</replaceable></option> is
       specified (Fabien Coelho, Tom Lane)
      </para>
+____________________________________________________________________________-->
+     <para>
+      当指定<option>--random-seed=<replaceable>N</replaceable></option>时，使<application>pgbench</application>随机数生成完全确定且平台无关 (Fabien Coelho, Tom Lane)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       On any specific platform, the sequence obtained with a particular
       value of <replaceable>N</replaceable> will probably be different
       from what it was before this patch.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      在任何特定平台上，用指定的<replaceable>N</replaceable>值获得的序列可能与打上补丁之前的序列不同。
      </para>
     </listitem>
 
@@ -1095,10 +1548,15 @@ Branch: REL_11_STABLE [85036308d] 2018-11-30 10:15:06 +0900
 Branch: master [5c9951397] 2018-11-30 10:34:45 +0900
 Branch: REL_11_STABLE [19516afdf] 2018-11-30 10:34:56 +0900
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix <application>pg_basebackup</application>
       and <application>pg_verify_checksums</application> to ignore
       temporary files appropriately (Michael Banck, Michael Paquier)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      修复<application>pg_basebackup</application>和<application>pg_verify_checksums</application>以适当地忽略临时文件 (Michael Banck, Michael Paquier)
      </para>
     </listitem>
 
@@ -1112,17 +1570,27 @@ Branch: REL9_6_STABLE [16e0464a1] 2019-02-04 17:20:02 -0500
 Branch: REL9_5_STABLE [9368ba174] 2019-02-04 17:20:02 -0500
 Branch: REL9_4_STABLE [2f93b74bf] 2019-02-04 17:20:02 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix <application>pg_dump</application>'s handling of materialized
       views with indirect dependencies on primary keys (Tom Lane)
      </para>
+____________________________________________________________________________-->
+     <para>
+      修复<application>pg_dump</application>对间接依赖主键的物化视图的处理 (Tom Lane)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       This led to mis-labeling of such views' dump archive entries,
       causing harmless warnings about <quote>archive items not in correct
       section order</quote>; less harmlessly, selective-restore options
-      depending on those labels, such as <option>--section</option>, might
+      depending on those labels, such as <option>-&minus;section</option>, might
       misbehave.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      这导致对此类视图的转储归档条目的错误标记，从而导致有关“归档项的片段顺序不对”的无害警告；害处不大的是，依赖于这些标签的选择性恢复选项（例如<option>--section</option>）可能会出现错误行为。
      </para>
     </listitem>
 
@@ -1132,15 +1600,26 @@ Author: Michael Paquier <michael@paquier.xyz>
 Branch: master [e4fca461a] 2018-12-18 09:28:16 +0900
 Branch: REL_11_STABLE [d0960eb8a] 2018-12-18 09:28:56 +0900
 -->
+<!--==========================orignal english content==========================
      <para>
       Make <application>pg_dump</application> include <command>ALTER INDEX
       SET STATISTICS</command> commands (Michael Paquier)
      </para>
+____________________________________________________________________________-->
+     <para>
+      使<application>pg_dump</application>包含<command>ALTER INDEX
+      SET STATISTICS</command>命令 (Michael Paquier)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       When the ability to attach statistics targets to index expressions
       was added, we forgot to teach <application>pg_dump</application>
       about it, so that such settings were lost in dump/reload.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      当添加了将统计目标附加到索引表达式的功能时，我们忘记教<application>pg_dump</application>处理相关内容，因此在转储/重载中丢掉了这些设置。
      </para>
     </listitem>
 
@@ -1150,14 +1629,24 @@ Author: Peter Eisentraut <peter_e@gmx.net>
 Branch: master [6178f3cb7] 2018-11-13 09:41:20 +0100
 Branch: REL_11_STABLE [b72b4fafb] 2018-11-13 09:41:34 +0100
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix <application>pg_dump</application>'s dumping of tables that have
       OIDs (Peter Eisentraut)
      </para>
+____________________________________________________________________________-->
+     <para>
+      修复<application>pg_dump</application>对具有OID的表的转储 (Peter Eisentraut)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       The <literal>WITH OIDS</literal> clause was omitted if it needed to
       be applied to the first table to be dumped.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      如果需要将<literal>WITH OIDS</literal>子句应用于要转储的第一个表，则省略该子句。
      </para>
     </listitem>
 
@@ -1171,11 +1660,16 @@ Branch: REL9_6_STABLE [2b6009e2a] 2019-02-09 19:45:38 -0500
 Branch: REL9_5_STABLE [2c8332177] 2019-02-09 19:45:38 -0500
 Branch: REL9_4_STABLE [ed46d0d32] 2019-02-09 19:45:38 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Avoid null-pointer-dereference crash on some platforms
       when <application>pg_dump</application>
       or <application>pg_restore</application> tries to report an error
       (Tom Lane)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      避免在某些平台上，当<application>pg_dump</application>或<application>pg_restore</application>尝试报告错误时发生空指针解引用崩溃 (Tom Lane)
      </para>
     </listitem>
 
@@ -1185,10 +1679,15 @@ Author: Peter Geoghegan <pg@bowt.ie>
 Branch: master [eba775345] 2019-02-06 15:54:19 -0800
 Branch: REL_11_STABLE [2f5416666] 2019-02-06 15:54:17 -0800
 -->
+<!--==========================orignal english content==========================
      <para>
       Prevent false index-corruption reports
       from <filename>contrib/amcheck</filename> caused by
       inline-compressed data (Peter Geoghegan)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      防止由于内联压缩数据导致的<filename>contrib/amcheck</filename>错误索引损坏报告 (Peter Geoghegan)
      </para>
     </listitem>
 
@@ -1205,16 +1704,26 @@ Branch: master [ade2d61ed] 2018-12-16 14:32:14 -0500
 Branch: REL_11_STABLE [b1894a607] 2018-12-16 14:32:14 -0500
 Branch: REL_10_STABLE [34010ac2f] 2018-12-16 14:32:14 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Properly disregard <literal>SIGPIPE</literal> errors if <command>COPY
       FROM PROGRAM</command> stops reading the program's output early
       (Tom Lane)
      </para>
+____________________________________________________________________________-->
+     <para>
+      如果<command>COPY FROM PROGRAM</command>早先停止读取程序输出，则适当地忽略<literal>SIGPIPE</literal>错误 (Tom Lane)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       This case isn't actually reachable directly
       with <command>COPY</command>, but it can happen when
       using <filename>contrib/file_fdw</filename>.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      这种情况实际上不能直接通过<command>COPY</command>达到，但是在使用<filename>contrib/file_fdw</filename>时可能会发生。
      </para>
     </listitem>
 
@@ -1228,12 +1737,18 @@ Branch: REL9_6_STABLE [239abfff1] 2018-11-24 21:17:09 +0000
 Branch: REL9_5_STABLE [8087788f6] 2018-11-24 21:17:09 +0000
 Branch: REL9_4_STABLE [e5a6ae97e] 2018-11-24 21:17:09 +0000
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix <filename>contrib/hstore</filename> to calculate correct hash
       values for empty <type>hstore</type> values that were created in
       version 8.4 or before (Andrew Gierth)
      </para>
+____________________________________________________________________________-->
+     <para>
+      修复<filename>contrib/hstore</filename>以计算在版本8.4或之前版本创建的空<type>hstore</type>值的正确的哈希值 (Andrew Gierth)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       The previous coding did not give the same result as for an
       empty <type>hstore</type> value created by a newer version, thus
@@ -1242,6 +1757,10 @@ Branch: REL9_4_STABLE [e5a6ae97e] 2018-11-24 21:17:09 +0000
       built on <type>hstore</type> columns, if the table might contain
       data that was originally stored as far back as 8.4 and was never
       dumped/reloaded since then.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      之前的编码并未给出与新版本创建的空<type>hstore</type>值相同的结果，因此可能导致哈希连接或哈希聚集中出现错误结果。如果表中可能包含早在8.4之前就存储的数据，并且从那时起从未转储/重新加载过这些数据，则建议对基于<type>hstore</type>列构建的任何哈希索引重新做索引。
      </para>
     </listitem>
 
@@ -1255,10 +1774,15 @@ Branch: REL9_6_STABLE [5f11a500f] 2018-11-24 08:39:55 +0000
 Branch: REL9_5_STABLE [f0bfc7a2b] 2018-11-24 08:39:58 +0000
 Branch: REL9_4_STABLE [2f30b311d] 2018-11-24 08:40:02 +0000
 -->
+<!--==========================orignal english content==========================
      <para>
       Avoid crashes and excessive runtime with large inputs
       to <filename>contrib/intarray</filename>'s <literal>gist__int_ops</literal>
       index support (Andrew Gierth)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      避免向<filename>contrib/intarray</filename>的<literal>gist__int_ops</literal>索引支持提供大量输入时崩溃和过多的运行时间 (Andrew Gierth)
      </para>
     </listitem>
 
@@ -1269,16 +1793,26 @@ Branch: master [7291733ac] 2019-01-13 10:23:48 +0100
 Branch: REL_11_STABLE [3d498c65a] 2019-01-13 10:24:21 +0100
 Branch: REL_10_STABLE [cd1873160] 2019-01-13 10:25:23 +0100
 -->
+<!--==========================orignal english content==========================
      <para>
       In <application>configure</application>, look
       for <command>python3</command> and then <command>python2</command>
       if <command>python</command> isn't found (Peter Eisentraut)
      </para>
+____________________________________________________________________________-->
+     <para>
+      在<application>configure</application>时，如果没有找到<command>python</command>，则接着找<command>python3</command>，然后是<command>python2</command> (Peter Eisentraut)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       This allows PL/Python to be configured without explicitly
       specifying <literal>PYTHON</literal> on platforms that no longer
       provide an unversioned <command>python</command> executable.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      这允许在已不提供无版本号的<command>python</command>可执行文件的平台上配置PL/Python，而无需显式指定<literal>PYTHON</literal>。
      </para>
     </listitem>
 
@@ -1288,9 +1822,14 @@ Author: Andres Freund <andres@anarazel.de>
 Branch: master [5c1186751] 2019-01-28 13:51:12 -0800
 Branch: REL_11_STABLE [453be7d4d] 2019-01-28 13:53:43 -0800
 -->
+<!--==========================orignal english content==========================
      <para>
       Include JIT-related headers in the installed set of header files
       (Donald Dong)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      在已安装的头文件集中包含与JIT相关的头文件 (Donald Dong)
      </para>
     </listitem>
 
@@ -1304,15 +1843,25 @@ Branch: REL9_6_STABLE [5e63df827] 2019-02-03 17:48:53 +0900
 Branch: REL9_5_STABLE [12ff406f3] 2019-02-03 17:48:59 +0900
 Branch: REL9_4_STABLE [42b204db2] 2019-02-03 17:49:04 +0900
 -->
+<!--==========================orignal english content==========================
      <para>
       Support new Makefile
       variables <literal>PG_CFLAGS</literal>, <literal>PG_CXXFLAGS</literal>,
       and <literal>PG_LDFLAGS</literal> in <application>pgxs</application>
       builds (Christoph Berg)
      </para>
+____________________________________________________________________________-->
+     <para>
+      在<application>pgxs</application>构建中，支持新的Makefile变量<literal>PG_CFLAGS</literal>, <literal>PG_CXXFLAGS</literal>和<literal>PG_LDFLAGS</literal> (Christoph Berg)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       This simplifies customization of extension build processes.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      这简化了扩展构建过程的定制。
      </para>
     </listitem>
 
@@ -1341,10 +1890,15 @@ Branch: REL9_6_STABLE [be037c11b] 2019-02-05 10:05:17 -0500
 Branch: REL9_5_STABLE [a82ca6ffb] 2019-02-05 10:05:57 -0500
 Branch: REL9_4_STABLE [51884fa16] 2019-02-05 10:06:12 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix Perl-coded build scripts to not
       assume <quote><literal>.</literal></quote> is in the search path,
       since recent Perl versions don't include that (Andrew Dunstan)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      修复用Perl编写的构建脚本，不在假定<quote><literal>.</literal></quote>在搜索路径中，因为最近的Perl版本并不包含该功能 (Andrew Dunstan)
      </para>
     </listitem>
 
@@ -1358,8 +1912,13 @@ Branch: REL9_6_STABLE [167ba6b15] 2019-01-18 15:06:26 -0500
 Branch: REL9_5_STABLE [dc2dee438] 2019-01-18 15:06:26 -0500
 Branch: REL9_4_STABLE [b161ffe31] 2019-01-18 15:06:26 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix server command-line option parsing problems on OpenBSD (Tom Lane)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      修复OpenBSD上服务器命令行选项分析的问题 (Tom Lane)
      </para>
     </listitem>
 
@@ -1371,14 +1930,24 @@ Branch: REL_11_STABLE [027b5a300] 2019-02-09 11:41:09 -0500
 Branch: REL_10_STABLE [dc0eb137f] 2019-02-09 11:41:09 -0500
 Branch: REL9_6_STABLE [6257f525a] 2019-02-09 11:41:09 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Relocate call of <literal>set_rel_pathlist_hook</literal> so that
       extensions can use it to supply partial paths for parallel queries
       (KaiGai Kohei)
      </para>
+____________________________________________________________________________-->
+     <para>
+      重新定位<literal>set_rel_pathlist_hook</literal>的调用，以便扩展程序可以用它来为并行查询提供部分路径 (KaiGai Kohei)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       This is not expected to affect existing use-cases.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      这不会影响现有的用例。
      </para>
     </listitem>
 
@@ -1392,6 +1961,7 @@ Branch: REL9_6_STABLE [f6db9f8ab] 2019-02-05 10:59:23 -0500
 Branch: REL9_5_STABLE [4232a650b] 2019-02-05 10:59:31 -0500
 Branch: REL9_4_STABLE [a683df403] 2019-02-05 10:59:38 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Update time zone data files to <application>tzdata</application>
       release 2018i for DST law changes in Kazakhstan, Metlakatla, and Sao
@@ -1399,6 +1969,10 @@ Branch: REL9_4_STABLE [a683df403] 2019-02-05 10:59:38 -0500
       creating a new zone Asia/Qostanay, as some areas did not change UTC
       offset.  Historical corrections for Hong Kong and numerous Pacific
       islands.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      将时区文件更新为<application>tzdata</application> 2018i版本，以应对哈萨克斯坦、梅特拉卡特拉、圣多美和普林西比的DST法律变更。哈萨克斯坦的Qyzylorda区一分为二，从而创建了一个新的Asia/Qostanay区，因为某些地区没有改变UTC偏移量。对香港（中国）和众多太平洋岛屿的历史性更正。
      </para>
     </listitem>
 
@@ -1408,34 +1982,64 @@ Branch: REL9_4_STABLE [a683df403] 2019-02-05 10:59:38 -0500
  </sect1>
 
  <sect1 id="release-11-1">
+<!--==========================orignal english content==========================
   <title>Release 11.1</title>
+____________________________________________________________________________-->
+  <title>版本11.1</title>
 
   <formalpara>
+<!--==========================orignal english content==========================
   <title>Release date:</title>
+____________________________________________________________________________-->
+  <title>发布日期:</title>
+<!--==========================orignal english content==========================
+  <para>2018-11-08</para>
+____________________________________________________________________________-->
   <para>2018-11-08</para>
   </formalpara>
 
+<!--==========================orignal english content==========================
   <para>
    This release contains a variety of fixes from 11.0.
    For information about new features in major release 11, see
    <xref linkend="release-11"/>.
   </para>
+____________________________________________________________________________-->
+  <para>
+   本次发布包含了对11.0的一些修正。主版本11的新特性的有关信息，见<xref linkend="release-11"/>。
+  </para>
 
   <sect2>
+<!--==========================orignal english content==========================
    <title>Migration to Version 11.1</title>
+____________________________________________________________________________-->
+   <title>迁移到版本11.1</title>
 
+<!--==========================orignal english content==========================
    <para>
     A dump/restore is not required for those running 11.X.
    </para>
+____________________________________________________________________________-->
+   <para>
+    对于运行11.X的，不需要转储/恢复。
+   </para>
 
+<!--==========================orignal english content==========================
    <para>
     However, if you use the <filename>pg_stat_statements</filename> extension,
     see the changelog entry below about that.
    </para>
+____________________________________________________________________________-->
+   <para>
+    但如果使用<filename>pg_stat_statements</filename>扩展，参见下面修改日志入口的有关内容。
+   </para>
   </sect2>
 
   <sect2>
+<!--==========================orignal english content==========================
    <title>Changes</title>
+____________________________________________________________________________-->
+   <title>修改列表</title>
 
    <itemizedlist>
 
@@ -1446,16 +2050,26 @@ Branch: master [350410be4] 2018-10-19 00:50:16 -0400
 Branch: REL_11_STABLE [06292bb94] 2018-10-19 00:50:16 -0400
 Branch: REL_10_STABLE [09397f0ed] 2018-10-19 00:50:17 -0400
 -->
+<!--==========================orignal english content==========================
      <para>
       Ensure proper quoting of transition table names
       when <application>pg_dump</application> emits <command>CREATE TRIGGER
       ... REFERENCING</command> commands (Tom Lane)
      </para>
+____________________________________________________________________________-->
+     <para>
+      当<application>pg_dump</application>发出<command>CREATE TRIGGER ... REFERENCING</command>命令时，要确保对转换表名加引号 (Tom Lane)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       This oversight could be exploited by an unprivileged user to gain
       superuser privileges during the next dump/reload
       or <application>pg_upgrade</application> run.  (CVE-2018-16850)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      此疏忽可被非特权用户利用，在下次转储/重载或<application>pg_upgrade</application>运行时获取到超级用户特权。(CVE-2018-16850)
      </para>
     </listitem>
 
@@ -1465,14 +2079,24 @@ Author: Alvaro Herrera <alvherre@alvh.no-ip.org>
 Branch: master [dfa608141] 2018-11-03 13:25:19 -0300
 Branch: REL_11_STABLE [33e6c34c3] 2018-11-03 13:25:29 -0300
 -->
+<!--==========================orignal english content==========================
      <para>
       Apply the tablespace specified for a partitioned index when creating a
       child index (&Aacute;lvaro Herrera)
      </para>
+____________________________________________________________________________-->
+     <para>
+      创建孩子索引时，应用为分区索引指定的表空间 (&Aacute;lvaro Herrera)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       Previously, child indexes were always created in the default
       tablespace.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      以前，一直是在缺省表空间中创建孩子索引。
      </para>
     </listitem>
 
@@ -1482,14 +2106,25 @@ Author: Thomas Munro <tmunro@postgresql.org>
 Branch: master [1ce4a807e] 2018-11-03 11:05:35 +1300
 Branch: REL_11_STABLE [fd6449aa3] 2018-11-03 11:08:03 +1300
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix NULL handling in parallel hashed multi-batch left joins (Andrew
       Gierth, Thomas Munro)
      </para>
+____________________________________________________________________________-->
+     <para>
+      修复在做并行哈希的多批左连接中NULL处理的问题 (Andrew
+      Gierth, Thomas Munro)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       Outer-relation rows with null values of the hash key were omitted from
       the join result.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      连接结果中忽略哈希键为空值的外关系行。
      </para>
     </listitem>
 
@@ -1499,10 +2134,15 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
 Branch: master [14a158f9b] 2018-10-30 15:26:11 -0400
 Branch: REL_11_STABLE [2bd6dcdef] 2018-10-30 15:26:11 -0400
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix incorrect processing of an array-type coercion expression
       appearing within a <literal>CASE</literal> clause that has a constant
       test expression (Tom Lane)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      修复出现在有常量测试表达式的<literal>CASE</literal>子句中对数组类型强制型转表达式的不正确处理  (Tom Lane)
      </para>
     </listitem>
 
@@ -1512,14 +2152,24 @@ Author: Andrew Dunstan <andrew@dunslane.net>
 Branch: master [040a1df61] 2018-10-24 10:56:27 -0400
 Branch: REL_11_STABLE [372102b81] 2018-10-24 10:57:35 -0400
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix incorrect expansion of tuples lacking recently-added columns
       (Andrew Dunstan, Amit Langote)
      </para>
+____________________________________________________________________________-->
+     <para>
+      修复缺少最近添加列的元组的不正确的扩张 (Andrew Dunstan, Amit Langote)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       This is known to lead to crashes in triggers on tables with
       recently-added columns, and could have other symptoms as well.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      众所周知，这会导致在有最近添加列的表上的触发器中崩溃，也还会有其他问题。
      </para>
     </listitem>
 
@@ -1531,9 +2181,14 @@ Branch: REL_11_STABLE [4b0c3712c] 2018-11-04 13:25:39 -0500
 Branch: master [9b6fb9fbb] 2018-11-04 14:50:55 -0500
 Branch: REL_11_STABLE [d358da814] 2018-11-04 14:50:55 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix bugs with named or defaulted arguments in <command>CALL</command>
       argument lists (Tom Lane, Pavel Stehule)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      修复<command>CALL</command>参数列表中命名和缺省参数的BUG (Tom Lane, Pavel Stehule)
      </para>
     </listitem>
 
@@ -1545,14 +2200,24 @@ Branch: REL_11_STABLE [fd59b29c8] 2018-11-03 14:48:42 -0700
 Branch: master [793beab37] 2018-11-03 15:55:23 -0700
 Branch: REL_11_STABLE [6eb31cedb] 2018-11-03 16:00:00 -0700
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix strictness check for strict aggregates with <literal>ORDER
       BY</literal> columns (Andrew Gierth, Andres Freund)
      </para>
+____________________________________________________________________________-->
+     <para>
+      修复对有<literal>ORDER BY</literal>列的严格聚集的严格性检查 (Andrew Gierth, Andres Freund)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       The strictness logic incorrectly ignored rows for which
       the <literal>ORDER BY</literal> value(s) were null.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      严格性逻辑错误地忽略了<literal>ORDER BY</literal>值为空值的行。
      </para>
     </listitem>
 
@@ -1562,13 +2227,23 @@ Author: Tom Lane <tgl@sss.pgh.pa.us>
 Branch: master [5d28c9bd7] 2018-11-06 18:33:28 -0500
 Branch: REL_11_STABLE [05f84605d] 2018-11-06 18:33:33 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Disable <varname>recheck_on_update</varname> optimization (Tom Lane)
      </para>
+____________________________________________________________________________-->
+     <para>
+      禁用<varname>recheck_on_update</varname>优化 (Tom Lane)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       This new-in-v11 feature turns out not to have been ready for prime
       time.  Disable it until something can be done about it.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      版本11中的这项新特性有点“生不逢时”。先禁用它，直到可以做点什么关于它的。
      </para>
     </listitem>
 
@@ -1579,14 +2254,24 @@ Branch: master [dc3e436b1] 2018-11-05 11:04:02 +0900
 Branch: REL_11_STABLE [7c222d5e5] 2018-11-05 11:04:14 +0900
 Branch: REL_10_STABLE [8aad248f7] 2018-11-05 11:04:20 +0900
 -->
+<!--==========================orignal english content==========================
      <para>
       Prevent creation of a partition in a trigger attached to its parent
       table (Amit Langote)
      </para>
+____________________________________________________________________________-->
+     <para>
+      防止在附加到其父表的触发器中创建分区 (Amit Langote)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       Ideally we'd allow that, but for the moment it has to be blocked to
       avoid crashes.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      理想情况下，允许这么做，但现在为了避免崩溃阻止这么做。
      </para>
     </listitem>
 
@@ -1597,9 +2282,14 @@ Branch: master [4bc772e2a] 2018-11-05 09:14:33 +0900
 Branch: REL_11_STABLE [948af5232] 2018-11-05 09:15:08 +0900
 Branch: REL_10_STABLE [70c38e708] 2018-11-05 09:15:25 +0900
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix problems with applying <literal>ON COMMIT DELETE ROWS</literal> to
       a partitioned temporary table (Amit Langote)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      修复将<literal>ON COMMIT DELETE ROWS</literal>应用于已分区的临时表的问题 (Amit Langote)
      </para>
     </listitem>
 
@@ -1614,15 +2304,25 @@ Branch: REL9_5_STABLE [6e6092989] 2018-11-03 13:56:10 -0400
 Branch: REL9_4_STABLE [0ae902e39] 2018-11-03 13:56:10 -0400
 Branch: REL9_3_STABLE [33c697e9d] 2018-11-03 13:56:10 -0400
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix character-class checks to not fail on Windows for Unicode
       characters above U+FFFF (Tom Lane, Kenji Uno)
      </para>
+____________________________________________________________________________-->
+     <para>
+      修复字符类的检查，这样在Windows上，对于U+FFFF以上的Unicode字符不会失败 (Tom Lane, Kenji Uno)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       This bug affected full-text-search operations, as well
       as <filename>contrib/ltree</filename>
       and <filename>contrib/pg_trgm</filename>.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      该BUG既影响全文搜索的操作，也影响<filename>contrib/ltree</filename>和<filename>contrib/pg_trgm</filename>。
      </para>
     </listitem>
 
@@ -1635,11 +2335,16 @@ Branch: REL_10_STABLE [3bdef6d21] 2018-10-19 21:39:21 -0400
 Branch: REL9_6_STABLE [cbab94077] 2018-10-19 21:39:22 -0400
 Branch: REL9_5_STABLE [f4941666a] 2018-10-19 21:39:22 -0400
 -->
+<!--==========================orignal english content==========================
      <para>
       Ensure that the server will process
       already-received <literal>NOTIFY</literal>
       and <literal>SIGTERM</literal> interrupts before waiting for client
       input (Jeff Janes, Tom Lane)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      确保服务器在等待客户端输入之前处理已接收的<literal>NOTIFY</literal>和<literal>SIGTERM</literal>中断 (Jeff Janes, Tom Lane)
      </para>
     </listitem>
 
@@ -1654,14 +2359,24 @@ Branch: REL9_5_STABLE [156a737a6] 2018-10-31 17:04:43 -0400
 Branch: REL9_4_STABLE [95015b1f8] 2018-10-31 17:04:43 -0400
 Branch: REL9_3_STABLE [82dd1c271] 2018-10-31 17:04:43 -0400
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix memory leak in repeated SP-GiST index scans (Tom Lane)
      </para>
+____________________________________________________________________________-->
+     <para>
+      修复反复进行SP-GiST索引扫描时的内存泄露 (Tom Lane)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       This is only known to amount to anything significant in cases where
       an exclusion constraint using SP-GiST receives many new index entries
       in a single command.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      这只有在单一命令中使用了SP-GiST的排除约束收到很多的索引项时才比较明显。
      </para>
     </listitem>
 
@@ -1675,9 +2390,15 @@ Branch: REL9_6_STABLE [d35fd17cb] 2018-10-31 15:46:40 -0700
 Branch: REL9_5_STABLE [679cb44e4] 2018-10-31 15:46:40 -0700
 Branch: REL9_4_STABLE [cf358a2c0] 2018-10-31 15:46:40 -0700
 -->
+<!--==========================orignal english content==========================
      <para>
       Prevent starting the server with <varname>wal_level</varname> set
       to too low a value to support an existing replication slot (Andres
+      Freund)
+     </para>
+____________________________________________________________________________-->
+     <para>
+      防止服务器启动时的<varname>wal_level</varname>值设得太低以至于无法支持一个已有的复制槽 (Andres
       Freund)
      </para>
     </listitem>
@@ -1691,16 +2412,26 @@ Branch: REL_10_STABLE [ecc59e31a] 2018-10-19 22:22:57 -0400
 Branch: REL9_6_STABLE [34aad21cb] 2018-10-19 22:22:57 -0400
 Branch: REL9_5_STABLE [ac3be116a] 2018-10-19 22:22:57 -0400
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix <application>psql</application>, as well as documentation
       examples, to call <function>PQconsumeInput()</function> before
       each <function>PQnotifies()</function> call (Tom Lane)
      </para>
+____________________________________________________________________________-->
+     <para>
+      修复<application>psql</application>和文档的例子，在每次调用<function>PQnotifies()</function>之前调用<function>PQconsumeInput()</function> (Tom Lane)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       This fixes cases in which <application>psql</application> would not
       report receipt of a <literal>NOTIFY</literal> message until after the
       next command.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      这修复了直到下一条命令之后<application>psql</application>才能报告<literal>NOTIFY</literal>消息的接收情况。
      </para>
     </listitem>
 
@@ -1710,14 +2441,24 @@ Author: Michael Paquier <michael@paquier.xyz>
 Branch: master [d55241af7] 2018-10-19 22:44:12 +0900
 Branch: REL_11_STABLE [cc7f27eae] 2018-10-19 22:45:07 +0900
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix <application>pg_verify_checksums</application>'s determination of
       which files to check the checksums of (Michael Paquier)
      </para>
+____________________________________________________________________________-->
+     <para>
+      修复<application>pg_verify_checksums</application>，确定哪些文件要做校验和 (Michael Paquier)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       In some cases it complained about files that are not expected to have
       checksums.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      用户抱怨有些情况下一些文件无需校验和。
      </para>
     </listitem>
 
@@ -1728,18 +2469,29 @@ Branch: master [edb979766] 2018-09-25 09:55:44 +0900
 Branch: REL_11_STABLE Release: REL_11_0 [a3bb831ef] 2018-09-25 09:56:41 +0900
 Branch: REL_10_STABLE [90a1f9786] 2018-09-25 09:56:57 +0900
 -->
+<!--==========================orignal english content==========================
      <para>
       In <filename>contrib/pg_stat_statements</filename>, disallow
       the <literal>pg_read_all_stats</literal> role from
       executing <function>pg_stat_statements_reset()</function>
       (Haribabu Kommi)
      </para>
+____________________________________________________________________________-->
+     <para>
+      在<filename>contrib/pg_stat_statements</filename>，不允许<literal>pg_read_all_stats</literal>角色执行<function>pg_stat_statements_reset()</function> (Haribabu Kommi)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       <literal>pg_read_all_stats</literal> is only meant to grant permission
       to read statistics, not to change them, so this grant was incorrect.
      </para>
+____________________________________________________________________________-->
+     <para>
+      <literal>pg_read_all_stats</literal>仅是为读统计授权，而不是改变它们，故该授权方式不正确。
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       To cause this change to take effect, run <literal>ALTER EXTENSION
       pg_stat_statements UPDATE</literal> in each database
@@ -1750,6 +2502,10 @@ Branch: REL_10_STABLE [90a1f9786] 2018-09-25 09:56:57 +0900
       <literal>UPDATE</literal> command is harmless if the module was
       already updated.)
      </para>
+____________________________________________________________________________-->
+     <para>
+      要使此修改生效，需要在每个安装了<filename>pg_stat_statements</filename>的数据库上运行<literal>ALTER EXTENSION pg_stat_statements UPDATE</literal>（新建的11.0版数据库不需要做这些，但从以前版本升级的数据库很可能还包含老版本的<filename>pg_stat_statements</filename>。即使该模块已经升级，<literal>UPDATE</literal>命令也是没有坏处的。）
+     </para>
     </listitem>
 
     <listitem>
@@ -1759,14 +2515,24 @@ Branch: master [003c68a3b] 2018-11-06 13:25:24 -0500
 Branch: REL_11_STABLE [1f28ec6be] 2018-11-06 13:25:24 -0500
 Branch: REL_10_STABLE [b2e754c14] 2018-11-06 13:25:24 -0500
 -->
+<!--==========================orignal english content==========================
      <para>
       Rename red-black tree support functions to use <literal>rbt</literal>
       prefix not <literal>rb</literal> prefix (Tom Lane)
      </para>
+____________________________________________________________________________-->
+     <para>
+      重命名红黑树支持函数，使用<literal>rbt</literal>前缀，而不是<literal>rb</literal>前缀 (Tom Lane)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       This avoids name collisions with Ruby functions, which broke
       PL/Ruby.  It's hoped that there are no other affected extensions.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      这将避免与Ruby函数的名字冲突。此类冲突会破坏PL/Ruby。希望其他扩展不受影响。
      </para>
     </listitem>
 
@@ -1802,10 +2568,16 @@ Branch: REL9_5_STABLE [6dc28d291] 2018-09-25 13:23:29 -0400
 Branch: REL9_4_STABLE [a5361b593] 2018-09-25 13:23:29 -0400
 Branch: REL9_3_STABLE [6019247a5] 2018-09-25 13:23:29 -0400
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix build problems on macOS 10.14 (Mojave) (Tom Lane)
      </para>
+____________________________________________________________________________-->
+     <para>
+      修复macOS 10.14(Mojave)上构建的问题 (Tom Lane)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       Adjust <application>configure</application> to add
       an <option>-isysroot</option> switch to <varname>CPPFLAGS</varname>;
@@ -1815,7 +2587,12 @@ Branch: REL9_3_STABLE [6019247a5] 2018-09-25 13:23:29 -0400
       the arguments of <application>configure</application>
       or <application>make</application>.
      </para>
+____________________________________________________________________________-->
+     <para>
+      调整<application>configure</application>，将<option>-isysroot</option>开关增加到<varname>CPPFLAGS</varname>；无此开关的话，在macOS 10.14上，PL/Perl和PL/Tcl配置或构建就会失败。通过在<application>configure</application>或<application>make</application>中设置<varname>PG_SYSROOT</varname>变量，所用的特定sysroot在配置或构建时会被覆盖。
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       It is now recommended that Perl-related extensions
       write <literal>$(perl_includespec)</literal> rather
@@ -1823,11 +2600,20 @@ Branch: REL9_3_STABLE [6019247a5] 2018-09-25 13:23:29 -0400
       flags.  The latter continues to work on most platforms, but not recent
       macOS.
      </para>
+____________________________________________________________________________-->
+     <para>
+      对于Perl有关的扩展，现在推荐在其编译标记处写<literal>$(perl_includespec)</literal>，而不是<literal>-I$(perl_archlibexp)/CORE</literal>。后者仍能工作，但最近的macOS不行。
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       Also, it should no longer be necessary to
-      specify <option>--with-tclconfig</option> manually to get PL/Tcl to
+      specify <option>-&minus;with-tclconfig</option> manually to get PL/Tcl to
       build on recent macOS releases.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      现在要在最近的macOS版本上构建PL/Tcl也不需要人工指定<option>--with-tclconfig</option>。
      </para>
     </listitem>
 
@@ -1842,14 +2628,24 @@ Branch: REL9_5_STABLE [ba103dc87] 2018-10-28 12:26:05 -0400
 Branch: REL9_4_STABLE [698255147] 2018-10-28 12:26:14 -0400
 Branch: REL9_3_STABLE [075641fd0] 2018-10-28 12:27:58 -0400
 -->
+<!--==========================orignal english content==========================
      <para>
       Fix MSVC build and regression-test scripts to work on recent Perl
       versions (Andrew Dunstan)
      </para>
+____________________________________________________________________________-->
+     <para>
+      修复MSVC的构建和回归测试脚本，以使其能在最近的Perl版本上工作 (Andrew Dunstan)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       Perl no longer includes the current directory in its search path
       by default; work around that.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      缺省情况下，Perl的搜索路径中不再包含当前目录；变通以解决之。
      </para>
     </listitem>
 
@@ -1862,14 +2658,24 @@ Branch: REL_10_STABLE [f4b67efdc] 2018-10-20 09:10:18 -0400
 Branch: REL9_6_STABLE [42a93da25] 2018-10-20 09:10:54 -0400
 Branch: REL9_5_STABLE [cc02db82c] 2018-10-20 09:11:18 -0400
 -->
+<!--==========================orignal english content==========================
      <para>
       On Windows, allow the regression tests to be run by an Administrator
       account (Andrew Dunstan)
      </para>
+____________________________________________________________________________-->
+     <para>
+      Windows上，允许由Administrator账户运行回归测试 (Andrew Dunstan)
+     </para>
 
+<!--==========================orignal english content==========================
      <para>
       To do this safely, <application>pg_regress</application> now gives up
       any such privileges at startup.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      为保险起见，<application>pg_regress</application>现在启动时会放弃任何此类特权。
      </para>
     </listitem>
 
@@ -1891,11 +2697,16 @@ Branch: REL9_5_STABLE [56170609b] 2018-10-19 17:02:12 -0400
 Branch: REL9_4_STABLE [9abbfc35c] 2018-10-19 17:02:20 -0400
 Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 -->
+<!--==========================orignal english content==========================
      <para>
       Update time zone data files to <application>tzdata</application>
       release 2018g for DST law changes in Chile, Fiji, Morocco, and Russia
       (Volgograd), plus historical corrections for China, Hawaii, Japan,
       Macau, and North Korea.
+     </para>
+____________________________________________________________________________-->
+     <para>
+      将时区数据文件更新为<application>tzdata</application> 2018g版，以适应智利、斐济、摩洛哥和俄罗斯（伏尔加格勒）的DST法律更改，以及中国、夏威夷、日本、澳门（中国）和朝鲜的历史更正。
      </para>
     </listitem>
 
@@ -1905,18 +2716,35 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
  </sect1>
 
  <sect1 id="release-11">
+<!--==========================orignal english content==========================
   <title>Release 11</title>
+____________________________________________________________________________-->
+  <title>版本11</title>
 
   <formalpara>
+<!--==========================orignal english content==========================
    <title>Release date:</title>
+____________________________________________________________________________-->
+   <title>发布日期:</title>
+<!--==========================orignal english content==========================
+   <para>2018-10-18</para>
+____________________________________________________________________________-->
    <para>2018-10-18</para>
   </formalpara>
 
   <sect2>
+<!--==========================orignal english content==========================
    <title>Overview</title>
+____________________________________________________________________________-->
+   <title>概述</title>
 
+<!--==========================orignal english content==========================
    <para>
     Major enhancements in <productname>PostgreSQL</productname> 11 include:
+   </para>
+____________________________________________________________________________-->
+   <para>
+    <productname>PostgreSQL</productname>11的主要改进有：
    </para>
 
    <!-- Items in this list summarize one or more items below -->
@@ -1924,6 +2752,7 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
    <itemizedlist>
 
     <listitem>
+<!--==========================orignal english content==========================
      <para>
       Improvements to partitioning functionality, including:
       <itemizedlist>
@@ -1959,9 +2788,41 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
        </listitem>
       </itemizedlist>
      </para>
+____________________________________________________________________________-->
+     <para>
+      分区功能的改进，包括：
+      <itemizedlist>
+       <listitem>
+        <para>
+         增加用哈希键分区的支持
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         增加分区表上<literal>PRIMARY KEY</literal>, <literal>FOREIGN KEY</literal>,索引和触发器的支持
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         允许创建<quote>default</quote>分区，以存储与其余分区都不匹配的数据
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         改变分区键列的<command>UPDATE</command>语句现在会导致受到影响的行移动到适当的分区
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         在查询计划和执行时通过增强分区排除策略来提高<command>SELECT</command>性能
+        </para>
+       </listitem>
+      </itemizedlist>
+     </para>
     </listitem>
 
     <listitem>
+<!--==========================orignal english content==========================
      <para>
       Improvements to parallelism, including:
       <itemizedlist>
@@ -1987,66 +2848,130 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
        </listitem>
       </itemizedlist>
      </para>
-    </listitem>
-
-    <listitem>
+____________________________________________________________________________-->
      <para>
-      SQL stored procedures that support embedded transactions
+      并行性改进，包括：
+      <itemizedlist>
+       <listitem>
+        <para>
+         现在构建B-树索引时<command>CREATE INDEX</command>可使用并行处理
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         现在<command>CREATE TABLE ... AS</command>,<command>CREATE MATERIALIZED VIEW</command>和某些使用<literal>UNION</literal>的查询中并行是可能的
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         并行化的哈希连接和并行化顺序扫描现在表现更好
+        </para>
+       </listitem>
+      </itemizedlist>
      </para>
     </listitem>
 
     <listitem>
+<!--==========================orignal english content==========================
+     <para>
+      SQL stored procedures that support embedded transactions
+     </para>
+____________________________________________________________________________-->
+     <para>
+      支持嵌入式事务的SQL存储过程
+     </para>
+    </listitem>
+
+    <listitem>
+<!--==========================orignal english content==========================
      <para>
       Optional Just-in-Time (JIT) compilation for some SQL code, speeding
       evaluation of expressions
      </para>
+____________________________________________________________________________-->
+     <para>
+      对于一些SQL代码，可用即时(JIT)编译加速表达式评估
+     </para>
     </listitem>
 
     <listitem>
+<!--==========================orignal english content==========================
      <para>
       Window functions now support all framing options shown in the SQL:2011
       standard, including <literal>RANGE <replaceable>distance</replaceable>
       PRECEDING/FOLLOWING</literal>, <literal>GROUPS</literal> mode, and
       frame exclusion options
      </para>
-    </listitem>
-
-    <listitem>
+____________________________________________________________________________-->
      <para>
-      Covering indexes can now be created, using the
-      <literal>INCLUDE</literal> clause of <command>CREATE INDEX</command>
+      窗口函数现在支持SQL:2011标准中的所有帧选项，包括<literal>RANGE <replaceable>distance </replaceable>PRECEDING/FOLLOWING</literal>, <literal>GROUPS</literal>模式和帧排除选项
      </para>
     </listitem>
 
     <listitem>
+<!--==========================orignal english content==========================
+     <para>
+      Covering indexes can now be created, using the
+      <literal>INCLUDE</literal> clause of <command>CREATE INDEX</command>
+     </para>
+____________________________________________________________________________-->
+     <para>
+      现在使用 <command>CREATE INDEX</command>的<literal>INCLUDE</literal>子句可创建覆盖索引
+     </para>
+    </listitem>
+
+    <listitem>
+<!--==========================orignal english content==========================
      <para>
       Many other useful performance improvements, including the ability to
       avoid a table rewrite for <command>ALTER TABLE ... ADD COLUMN</command>
       with a non-null column default
      </para>
+____________________________________________________________________________-->
+     <para>
+      其它很多有用的性能改进，包括在<command>ALTER TABLE ... ADD COLUMN</command>以非空列作为缺省时避免重写的能力
+     </para>
     </listitem>
 
    </itemizedlist>
 
+<!--==========================orignal english content==========================
    <para>
     The above items are explained in more detail in the sections below.
+   </para>
+____________________________________________________________________________-->
+   <para>
+    以上的项在下面的章节中详细说明。
    </para>
 
   </sect2>
 
   <sect2>
 
+<!--==========================orignal english content==========================
   <title>Migration to Version 11</title>
+____________________________________________________________________________-->
+  <title>迁移到版本11</title>
 
+<!--==========================orignal english content==========================
    <para>
     A dump/restore using <xref linkend="app-pg-dumpall"/>, or use of <xref
     linkend="pgupgrade"/>, is required for those wishing to migrate data
     from any previous release.
    </para>
+____________________________________________________________________________-->
+   <para>
+    要从任何以前的版本迁移数据，需要使用<xref linkend="app-pg-dumpall"/>或使用<xref linkend="pgupgrade"/>来转储/恢复。
+   </para>
 
+<!--==========================orignal english content==========================
    <para>
     Version 11 contains a number of changes that may affect compatibility
     with previous releases.  Observe the following incompatibilities:
+   </para>
+____________________________________________________________________________-->
+   <para>
+    版本11包含一些影响到与以前的版本的兼容性的修改。注意以下不兼容的方面：
    </para>
 
    <itemizedlist>
@@ -2058,35 +2983,51 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2018-01-25 [0d4e6ed30] Clean up some aspects of pg_dump/pg_restore item-selecti
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Make <link
         linkend="app-pgdump"><application>pg_dump</application></link>
         dump the properties of a database, not just its contents
         (Haribabu Kommi)
        </para>
+____________________________________________________________________________-->
+       <para>
+        使<link linkend="app-pgdump"><application>pg_dump</application></link>转储数据库属性，而不仅仅是其内容 (Haribabu Kommi)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Previously, attributes of the database itself, such as database-level
         <command>GRANT</command>/<command>REVOKE</command> permissions and
         <command>ALTER DATABASE SET</command> variable settings, were only
         dumped by <link linkend="app-pg-dumpall"><application>pg_dumpall</application></link>.
-        Now <command>pg_dump --create</command> and
-        <command>pg_restore --create</command> will restore these database
+        Now <command>pg_dump -&minus;create</command> and
+        <command>pg_restore -&minus;create</command> will restore these database
         properties in addition to the objects within the
         database.  <command>pg_dumpall -g</command> now only dumps role-
         and tablespace-related attributes.
         <application>pg_dumpall</application>'s complete output (without
         <option>-g</option>) is unchanged.
        </para>
+____________________________________________________________________________-->
+       <para>
+        以前，数据库本身的属性，例如数据库级的<command>GRANT</command>/<command>REVOKE</command>权限和<command>ALTER DATABASE SET</command>变量设置，仅由<link linkend="app-pg-dumpall"><application>pg_dumpall</application></link>来转储。现在<command>pg_dump --create</command> 和<command>pg_restore --create</command>将恢复数据库中的属性和对象。<command>pg_dumpall -g</command>现在仅转储角色和表空间相关属性。<application>pg_dumpall</application>的全部输出(无<option>-g</option>)未改变。
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         <application>pg_dump</application> and
         <application>pg_restore</application>, without
-        <option>--create</option>, no longer dump/restore database-level
+        <option>-&minus;create</option>, no longer dump/restore database-level
         comments and security labels; those are now treated as properties of
         the database.
        </para>
+____________________________________________________________________________-->
+       <para>
+        <application>pg_dump</application>和<application>pg_restore</application>，没有<option>--create</option>选项时，不在转储/恢复数据库级注释和安全标记，这些内容现在被当作数据库属性。
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         <application>pg_dumpall</application>'s output script will now always
         create databases with their original locale and encoding, and hence
@@ -2095,12 +3036,21 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
         would be emitted without these specifications if the database locale
         and encoding matched the old cluster's defaults.
        </para>
-
+____________________________________________________________________________-->
        <para>
-        <command>pg_dumpall --clean</command> now restores the original
+        <application>pg_dumpall</application>的输出脚本现在创建数据库时总与其原来的区域设置和编码一起，所以如果目的系统的区域设置和编码名称未知的话，就会失败。以前，如果数据库的区域设置和编码与旧集群的缺省设置匹配的话，则<command>CREATE DATABASE</command>命令无此要求即被发出。
+       </para>
+
+<!--==========================orignal english content==========================
+       <para>
+        <command>pg_dumpall -&minus;clean</command> now restores the original
         locale and encoding settings of the <literal>postgres</literal>
         and <literal>template1</literal> databases, as well as those of
         user-created databases.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        <command>pg_dumpall --clean</command>现在可恢复<literal>postgres</literal>和<literal>template1</literal>数据库原来的区域设置和编码设置，这与用户创建的数据库是一样的。
        </para>
       </listitem>
 
@@ -2110,11 +3060,17 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2018-06-18 [45e98ee73] Remove obsolete prohibition on function name matching a
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Consider syntactic form when disambiguating function versus column
         references (Tom Lane)
        </para>
+____________________________________________________________________________-->
+       <para>
+        消除函数与列引用的歧义时考虑句法形式 (Tom Lane)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         When <replaceable>x</replaceable> is a table name or composite
         column, <productname>PostgreSQL</productname> has traditionally
@@ -2129,23 +3085,37 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
         ambiguity, the interpretation that matches the syntactic form is
         chosen.
        </para>
+____________________________________________________________________________-->
+       <para>
+        当<replaceable>x</replaceable>是表名或复合列时，<productname>PostgreSQL</productname>通常认为<literal><replaceable>f</replaceable>(<replaceable>x</replaceable>)</literal>和<literal><replaceable>x</replaceable>.<replaceable>f</replaceable></literal>的句法形式是等价的。这就允许类似于写一个函数，然后使用时它象是一按需计算的列这样的小把戏。但是，如果两种解释都可行，一般总选择列解释，就会导致用户需要函数解释时出现奇怪的结果。现在，如果有歧义，将选择匹配句法形式的解释。
+       </para>
       </listitem>
 
       <listitem>
 <!--
 2018-09-04 [fb466d7b5] Fully enforce uniqueness of constraint names.
 -->
+<!--==========================orignal english content==========================
        <para>
         Fully enforce uniqueness of table and domain constraint names
         (Tom Lane)
        </para>
+____________________________________________________________________________-->
+       <para>
+        完全强制表和域约束名的唯一性 (Tom Lane)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         <productname>PostgreSQL</productname> expects the names of a table's
         constraints to be distinct, and likewise for the names of a domain's
         constraints.  However, there was not rigid enforcement of this, and
         previously there were corner cases where duplicate names could be
         created.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        <productname>PostgreSQL</productname>要求表名不同，约束名也不同。但是，对此没有严格的强制措施，以前出现过相同名可以创建的特殊案例。
        </para>
       </listitem>
 
@@ -2156,13 +3126,19 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2018-05-17 [d1fc750b5] Make numeric power() handle NaNs according to the modern
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Make <function>power(numeric, numeric)</function>
         and <function>power(float8, float8)</function>
         handle <literal>NaN</literal> inputs according to the POSIX standard
         (Tom Lane, Dang Minh Huong)
        </para>
+____________________________________________________________________________-->
+       <para>
+        使<function>power(numeric, numeric)</function>和<function>power(float8, float8)</function>按POSIX标准处理<literal>NaN</literal>输入 (Tom Lane, Dang Minh Huong)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         POSIX says that <literal>NaN ^ 0 = 1</literal> and <literal>1 ^ NaN
         = 1</literal>, but all other cases with <literal>NaN</literal>
@@ -2174,6 +3150,11 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
         the library doesn't, and there were also problems on some versions
         of Windows.
        </para>
+____________________________________________________________________________-->
+       <para>
+        POSIX要求<literal>NaN ^ 0 = 1</literal>，<literal>1 ^ NaN
+        = 1</literal>，所有其他有<literal>NaN</literal>输入的情况都应返回<literal>NaN</literal>。在这些所有的情况下，<function>power(numeric, numeric)</function>正好返回<literal>NaN</literal>；现在接受两种异常。<function>power(float8, float8)</function>遵循标准只要C库支持；但在一些老的Unix平台上C库并未遵循标准，在Windows的一些版本上也有问题。
+       </para>
       </listitem>
 
       <listitem>
@@ -2181,19 +3162,29 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2017-11-17 [e87d4965b] Prevent to_number() from losing data when template doesn
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Prevent <link
         linkend="functions-formatting-numeric-table"><function>to_number()</function></link>
         from consuming characters when the template separator does not
         match (Oliver Ford)
        </para>
+____________________________________________________________________________-->
+       <para>
+        防止<link linkend="functions-formatting-numeric-table"><function>to_number()</function></link>在模板分隔符不匹配时消耗掉字符 (Oliver Ford)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Specifically, <command>SELECT to_number('1234', '9,999')</command>
         used to return <literal>134</literal>.  It will now
         return <literal>1234</literal>.  <literal>L</literal> and
         <literal>TH</literal> now only consume characters that are not
         digits, positive/negative signs, decimal points, or commas.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        特别地，<command>SELECT to_number('1234', '9,999')</command>过去返回<literal>134</literal>，现在返回<literal>1234</literal>。<literal>L</literal>和<literal>TH</literal>现在仅消掉非数字、正/负符号、小数点和逗号的字符。
        </para>
       </listitem>
 
@@ -2202,6 +3193,7 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2017-11-18 [976a1a48f] Improve to_date/to_number/to_timestamp behavior with mul
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Fix <link
         linkend="functions-formatting"><function>to_date()</function></link>,
@@ -2209,11 +3201,20 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
         <function>to_timestamp()</function> to skip a character for each
         template character (Tom Lane)
        </para>
+____________________________________________________________________________-->
+       <para>
+        修复<link linkend="functions-formatting"><function>to_date()</function></link>,<function>to_number()</function>和<function>to_timestamp()</function>，对于每个模板字符跳过一个字符 (Tom Lane)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Previously, they skipped one <emphasis>byte</emphasis> for each byte
         of template character, resulting in strange behavior if either string
         contained multibyte characters.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        以前，对于模板字符的每一字节，跳过一个<emphasis>byte</emphasis>。如果字符串包含多字节字符，则导致奇怪的行为。
        </para>
       </listitem>
 
@@ -2222,16 +3223,26 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2017-11-18 [63ca86318] Fix quoted-substring handling in format parsing for to_c
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Adjust the handling of backslashes inside double-quotes in
         template strings for <function>to_char()</function>,
         <function>to_number()</function>, and
         <function>to_timestamp()</function>.
        </para>
+____________________________________________________________________________-->
+       <para>
+        调整<function>to_char()</function>,<function>to_number()</function>和<function>to_timestamp()</function>模板字符串中双引号内的反斜杠的处理。
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Such a backslash now escapes the character after it, particularly
         a double-quote or another backslash.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        现在反斜杠将对其后面的字符转义，特别是双引号或其它反斜杠。
        </para>
       </listitem>
 
@@ -2240,16 +3251,26 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2018-06-21 [e474c2b7e] Set correct context for XPath evaluation
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Correctly handle relative path expressions
         in <function>xmltable()</function>, <function>xpath()</function>,
         and other XML-handling functions (Markus Winand)
        </para>
+____________________________________________________________________________-->
+       <para>
+        正确处理<function>xmltable()</function>, <function>xpath()</function>和其他XML处理函数中的相对路径表达式 (Markus Winand)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Per the SQL standard, relative paths start from the document node of
         the XML input document, not the root node as these functions
         previously did.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        根据SQL标准，相对路径是从XML输入文档的文档节点开始，而不是这些函数以前所用的根节点。
        </para>
       </listitem>
 
@@ -2259,12 +3280,17 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 
 -->
 
+<!--==========================orignal english content==========================
        <para>
         In the <link linkend="protocol-query-concepts">extended query
         protocol</link>,
         make <link linkend="guc-statement-timeout"><varname>statement_timeout</varname></link>
         apply to each Execute message separately, not to all commands before
         Sync (Tatsuo Ishii, Andres Freund)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        在<link linkend="protocol-query-concepts">扩展查询协议</link>中，使<link linkend="guc-statement-timeout"><varname>statement_timeout</varname></link>独立地应用于每个Execute消息，而不是Sync前的所有命令 (Tatsuo Ishii, Andres Freund)
        </para>
       </listitem>
 
@@ -2273,14 +3299,24 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2018-03-14 [f66e8bf87] Remove pg_class.relhaspkey
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Remove the <structfield>relhaspkey</structfield> column from system
         catalog <structname>pg_class</structname> (Peter Eisentraut)
        </para>
+____________________________________________________________________________-->
+       <para>
+        从系统目录<structname>pg_class</structname>删除<structfield>relhaspkey</structfield>列(Peter Eisentraut)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Applications needing to check for a primary key should consult
         <structname>pg_index</structname>.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        需要检查主键的应用程序应查询<structname>pg_index</structname>。
        </para>
       </listitem>
 
@@ -2289,16 +3325,26 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2018-03-02 [fd1a421fe] Add prokind column, replacing proisagg and proiswindow
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Replace system catalog <structname>pg_proc</structname>'s
         <structfield>proisagg</structfield> and
         <structfield>proiswindow</structfield> columns with
         <structfield>prokind</structfield> (Peter Eisentraut)
        </para>
+____________________________________________________________________________-->
+       <para>
+        系统目录<structname>pg_proc</structname>的<structfield>proisagg</structfield>和<structfield>proiswindow</structfield>列被替换为<structfield>prokind</structfield>  (Peter Eisentraut)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This new column more clearly distinguishes functions, procedures,
         aggregates, and window functions.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        新的列可更清晰地区分函数、过程、聚集和窗口函数。
        </para>
       </listitem>
 
@@ -2307,15 +3353,25 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2017-08-16 [9b5140fb5] Correct representation of foreign tables in information
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Correct information schema column <link
         linkend="infoschema-tables"><structname>tables</structname>.<structfield>table_type</structfield></link>
         to return <literal>FOREIGN</literal> instead of <literal>FOREIGN
         TABLE</literal> (Peter Eisentraut)
        </para>
+____________________________________________________________________________-->
+       <para>
+        纠正信息模式列<link linkend="infoschema-tables"><structname>tables</structname>.<structfield>table_type</structfield></link>，返回<literal>FOREIGN</literal>而不是<literal>FOREIGN TABLE</literal> (Peter Eisentraut)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This new output matches the SQL standard.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        新输出符合SQL标准。
        </para>
       </listitem>
 
@@ -2324,11 +3380,16 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2017-09-20 [be87b70b6] Sync process names between ps and pg_stat_activity
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Change the ps process display
         labels for background workers to match the <link
         linkend="pg-stat-activity-view"><structname>pg_stat_activity</structname>.<structfield>backend_type</structfield></link>
         labels (Peter Eisentraut)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        修改后台工作者的ps进程显示标记以匹配<link linkend="pg-stat-activity-view"><structname>pg_stat_activity</structname>.<structfield>backend_type</structfield></link>标记 (Peter Eisentraut)
        </para>
       </listitem>
 
@@ -2338,16 +3399,26 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2017-11-14 [6d776522d] Document changes in large-object privilege checking.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Cause large object permission checks
         to happen during large object open, <link
         linkend="lo-open"><function>lo_open()</function></link>, not
         when a read or write is attempted (Tom Lane, Michael Paquier)
        </para>
+____________________________________________________________________________-->
+       <para>
+        使大对象的权限检查在大对象打开即<link linkend="lo-open"><function>lo_open()</function></link>时进行，而不是在尝试读和写时进行 (Tom Lane, Michael Paquier)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         If write access is requested and not available, an error will now be
         thrown even if the large object is never written to.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        如果写访问已请求且未可用，现在会抛出一条错误，即使该大对象从未被写过。
        </para>
       </listitem>
 
@@ -2355,14 +3426,24 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 <!--
 2018-08-09 [87330e21c] Restrict access to reindex of shared catalogs for non-pr
 -->
+<!--==========================orignal english content==========================
        <para>
         Prevent non-superusers from reindexing shared catalogs
         (Michael Paquier, Robert Haas)
        </para>
+____________________________________________________________________________-->
+       <para>
+        防止非超级用户重建共享的目录索引 (Michael Paquier, Robert Haas)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Previously, database owners were also allowed to do this, but
         now it is considered outside the bounds of their privileges.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        以前，允许数据库的拥有者这么做，但现在被看作是在其权限边界之外。
        </para>
       </listitem>
 
@@ -2371,6 +3452,7 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2018-04-06 [11523e860] Support new default roles with adminpack
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Remove deprecated <link
         linkend="adminpack"><filename>adminpack</filename></link> functions
@@ -2378,12 +3460,21 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
         <function>pg_file_length()</function>, and
         <function>pg_logfile_rotate()</function> (Stephen Frost)
        </para>
+____________________________________________________________________________-->
+       <para>
+        移除过时的<link linkend="adminpack"><filename>adminpack</filename></link>函数<function>pg_file_read()</function>,<function>pg_file_length()</function>和<function>pg_logfile_rotate()</function> (Stephen Frost)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Equivalent functionality is now present in the core backend.
         Existing <filename>adminpack</filename> installs will continue to have
         access to these functions until they are updated via <command>ALTER
         EXTENSION ... UPDATE</command>.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        相同的功能现在在核心后端中。现有的<filename>adminpack</filename>安装可继续访问这些函数，直到用<command>ALTER EXTENSION ... UPDATE</command>更新为止。
        </para>
       </listitem>
 
@@ -2392,17 +3483,27 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2018-01-26 [fb8697b31] Avoid unnecessary use of pg_strcasecmp for already-downc
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Honor the capitalization of double-quoted command options
         (Daniel Gustafsson)
        </para>
+____________________________________________________________________________-->
+       <para>
+        遵守双引号命令选项的大写（规则）(Daniel Gustafsson)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Previously, option names in certain SQL commands were forcibly
         lower-cased even if entered with double quotes; thus for example
         <literal>"FillFactor"</literal> would be accepted as an index storage
         option, though properly its name is lower-case.  Such cases will now
         generate an error.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        以前，特定SQL命令中的选型名称是强制小写，即使有双引号；比如<literal>"FillFactor"</literal>将接受为索引存储选项，尽管其名字应为小写。这种情况现在会产生错误。
        </para>
       </listitem>
 
@@ -2411,13 +3512,23 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2017-09-29 [8b304b8b7] Remove replacement selection sort.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Remove server parameter <varname>replacement_sort_tuples</varname>
         (Peter Geoghegan)
        </para>
+____________________________________________________________________________-->
+       <para>
+        移除服务器参数<varname>replacement_sort_tuples</varname> (Peter Geoghegan)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Replacement sorts were determined to be no longer useful.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        经确认，不在使用替换排序。
        </para>
 
       </listitem>
@@ -2427,15 +3538,25 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2018-01-26 [4971d2a32] Remove the obsolete WITH clause of CREATE FUNCTION.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Remove <literal>WITH</literal> clause in <link
         linkend="sql-createfunction"><command>CREATE
         FUNCTION</command></link> (Michael Paquier)
        </para>
+____________________________________________________________________________-->
+       <para>
+        移除<link linkend="sql-createfunction"><command>CREATE FUNCTION</command></link>中的<literal>WITH</literal>子句 (Michael Paquier)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         <productname>PostgreSQL</productname> has long supported a more
         standard-compliant syntax for this capability.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        关于这种功能的一种更符合标准的语法，<productname>PostgreSQL</productname>已支持了很久。
        </para>
       </listitem>
 
@@ -2444,15 +3565,25 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2018-02-13 [4b93f5799] Make plpgsql use its DTYPE_REC code paths for composite-
 -->
 
+<!--==========================orignal english content==========================
        <para>
         In PL/pgSQL trigger functions, the <varname>OLD</varname>
         and <varname>NEW</varname> variables now read as NULL when not
         assigned (Tom Lane)
        </para>
+____________________________________________________________________________-->
+       <para>
+        PL/pgSQL触发器函数中，没有赋值时，变量<varname>OLD</varname>和<varname>NEW</varname>现在读出来是NULL (Tom Lane)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Previously, references to these variables could be parsed but not
         executed.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        以前，对这些变量的引用可被解析但不执行。
        </para>
       </listitem>
 
@@ -2461,19 +3592,33 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
   </sect2>
 
   <sect2>
+<!--==========================orignal english content==========================
    <title>Changes</title>
+____________________________________________________________________________-->
+   <title>修改列表</title>
 
+<!--==========================orignal english content==========================
    <para>
     Below you will find a detailed account of the changes between
     <productname>PostgreSQL</productname> 11 and the previous major
     release.
    </para>
+____________________________________________________________________________-->
+   <para>
+    下面是<productname>PostgreSQL</productname>11和以前主版本间的变更的详细说明。
+   </para>
 
    <sect3>
+<!--==========================orignal english content==========================
     <title>Server</title>
+____________________________________________________________________________-->
+    <title>服务器</title>
 
     <sect4>
+<!--==========================orignal english content==========================
      <title>Partitioning</title>
+____________________________________________________________________________-->
+     <title>分区</title>
 
      <itemizedlist>
 
@@ -2482,9 +3627,14 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2017-11-09 [1aba8e651] Add hash partitioning.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow the creation of partitions based on hashing a key column
         (Amul Sul)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        允许创建基于键列哈希的的分区 (Amul Sul)
        </para>
       </listitem>
 
@@ -2495,18 +3645,29 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2018-03-26 [555ee77a9] Handle INSERT .. ON CONFLICT with partitioned tables
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Support indexes on partitioned tables (&Aacute;lvaro Herrera,
         Amit Langote)
        </para>
+____________________________________________________________________________-->
+       <para>
+        支持分区表上的索引 (&Aacute;lvaro Herrera, Amit Langote)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         An <quote>index</quote> on a partitioned table is not a physical
         index across the whole partitioned table, but rather a template for
         automatically creating similar indexes on each partition of the
         table.
        </para>
+____________________________________________________________________________-->
+       <para>
+        分区表上的“索引”不是一种跨整个分区表的物理索引，而是一种自动创建表的每个分区上类似索引的模板。
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         If the partition key is part of the index's column set, a
         partitioned index may be declared <literal>UNIQUE</literal>.
@@ -2514,13 +3675,22 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
         partitioned table, even though each physical index only enforces
         uniqueness within its own partition.
        </para>
+____________________________________________________________________________-->
+       <para>
+        如果分区键是索引列集的一部分，分区索引可声明为<literal>UNIQUE</literal>。它将代表跨整个分区表的有效唯一性约束，即使每个物理索引仅强制其自己分区内的唯一性。
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         The new command <link linkend="sql-alterindex"><command>ALTER
         INDEX ATTACH PARTITION</command></link> causes an existing index on
         a partition to be associated with a matching index template for its
         partitioned table.  This provides flexibility in setting up a new
         partitioned index for an existing partitioned table.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        新命令<link linkend="sql-alterindex"><command>ALTER INDEX ATTACH PARTITION</command></link>使得分区表分区上已有索引与相配的索引模板关联。这样为已存在的分区表设置新的分区索引提供了灵活性。
        </para>
       </listitem>
 
@@ -2529,8 +3699,13 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2018-04-04 [3de241dba] Foreign keys on partitioned tables
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow foreign keys on partitioned tables (&Aacute;lvaro Herrera)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        允许分区表上的外键 (&Aacute;lvaro Herrera)
        </para>
       </listitem>
 
@@ -2539,15 +3714,25 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2018-03-23 [86f575948] Allow FOR EACH ROW triggers on partitioned tables
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow <literal>FOR EACH ROW</literal> triggers on partitioned
         tables (&Aacute;lvaro Herrera)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许分区表上的<literal>FOR EACH ROW</literal>触发器 (&Aacute;lvaro Herrera)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Creation of a trigger on a partitioned table automatically creates
         triggers on all existing and future partitions.
         This also allows deferred unique constraints on partitioned tables.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        创建分区表上的触发器，会自动创建所有已存在的和未来的分区上的触发器。这也允许分区表上可延迟的唯一约束。
        </para>
       </listitem>
 
@@ -2557,14 +3742,24 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2018-04-11 [72cf7f310] Fix ALTER TABLE .. ATTACH PARTITION ... DEFAULT
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow partitioned tables to have a default partition (Jeevan Ladhe,
         Beena Emerson, Ashutosh Bapat, Rahila Syed, Robert Haas)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许分区表有缺省分区 (Jeevan Ladhe, Beena Emerson, Ashutosh Bapat, Rahila Syed, Robert Haas)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         The default partition will store rows that don't match any of the
         other defined partitions, and is searched accordingly.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        缺省分区将存储与任何其他已定义分区不匹配的行，作相应的搜索。
        </para>
       </listitem>
 
@@ -2573,10 +3768,15 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2018-01-19 [2f1784410] Allow UPDATE to move rows between partitions.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         <command>UPDATE</command> statements that change a partition key
         column now cause affected rows to be moved to the appropriate
         partitions (Amit Khandekar)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        改变分区键列的<command>UPDATE</command>语句现在会使得受影响的行移动到适当的分区 (Amit Khandekar)
        </para>
       </listitem>
 
@@ -2585,15 +3785,25 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2018-04-06 [3d956d956] Allow insert and update tuple routing and COPY for forei
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow <command>INSERT</command>, <command>UPDATE</command>, and
         <command>COPY</command> on partitioned tables to properly route
         rows to foreign partitions (Etsuro Fujita, Amit Langote)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许分区表上的<command>INSERT</command>, <command>UPDATE</command>和<command>COPY</command>，将行正确地路由到外部分区 (Etsuro Fujita, Amit Langote)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This is supported by <filename>postgres_fdw</filename>
         foreign tables.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        该功能由<filename>postgres_fdw</filename>外部表支持。
        </para>
       </listitem>
 
@@ -2605,13 +3815,23 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2018-04-23 [055fb8d33] Add GUC enable_partition_pruning
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow faster partition elimination during query processing (Amit
         Langote, David Rowley, Dilip Kumar)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许查询处理时更快的分区排除 (Amit Langote, David Rowley, Dilip Kumar)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This speeds access to partitioned tables with many partitions.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        这将加速对有许多分区的分区表的访问。
        </para>
       </listitem>
 
@@ -2620,15 +3840,25 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2018-04-07 [499be013d] Support partition pruning at execution time
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow partition elimination during query execution (David Rowley,
         Beena Emerson)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许查询执行期间分区消除 (David Rowley, Beena Emerson)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Previously, partition elimination only happened at planning
         time, meaning many joins and prepared queries could not use
         partition elimination.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        以前，分区消除仅在计划期间发生，意味着许多连接和准备的查询不能使用分区消除。
        </para>
       </listitem>
 
@@ -2639,15 +3869,25 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2018-02-16 [2fb1abaeb] Rename enable_partition_wise_join to enable_partitionwis
 -->
 
+<!--==========================orignal english content==========================
        <para>
         In an equality join between partitioned tables, allow matching
         partitions to be joined directly (Ashutosh Bapat)
        </para>
+____________________________________________________________________________-->
+       <para>
+        分区表之间等值连接时，允许匹配的分区直接连接 (Ashutosh Bapat)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This feature is disabled by default
         but can be enabled by changing <link
         linkend="guc-enable-partitionwise-join"><varname>enable_partitionwise_join</varname></link>.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        该特性缺省是禁用的，可修改<link linkend="guc-enable-partitionwise-join"><varname>enable_partitionwise_join</varname></link>来启用。
        </para>
       </listitem>
 
@@ -2657,16 +3897,26 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2018-03-22 [e2f1eb0ee] Implement partition-wise grouping/aggregation.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow aggregate functions on partitioned tables to be evaluated
         separately for each partition, subsequently merging the results
         (Jeevan Chalke, Ashutosh Bapat, Robert Haas)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许分区表上的聚集函数对每个分区独立评估而后归并结果 (Jeevan Chalke, Ashutosh Bapat, Robert Haas)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This feature is disabled by default
         but can be enabled by changing <link
         linkend="guc-enable-partitionwise-aggregate"><varname>enable_partitionwise_aggregate</varname></link>.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        该特性缺省是禁用的，可修改<link linkend="guc-enable-partitionwise-aggregate"><varname>enable_partitionwise_aggregate</varname></link>来启用。
        </para>
       </listitem>
 
@@ -2675,11 +3925,16 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2018-04-02 [7e0d64c7a] postgres_fdw: Push down partition-wise aggregation.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow <link
         linkend="postgres-fdw"><filename>postgres_fdw</filename></link>
         to push down aggregates to foreign tables that are partitions
         (Jeevan Chalke)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        允许<link linkend="postgres-fdw"><filename>postgres_fdw</filename></link>将聚集下推到那些作为分区的外部表 (Jeevan Chalke)
        </para>
 
       </listitem>
@@ -2689,7 +3944,10 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
     </sect4>
 
     <sect4>
+<!--==========================orignal english content==========================
      <title>Parallel Queries</title>
+____________________________________________________________________________-->
+     <title>并行查询</title>
 
      <itemizedlist>
 
@@ -2698,9 +3956,14 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2018-02-02 [9da0cc352] Support parallel btree index builds.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow parallel building of a btree index (Peter Geoghegan,
         Rushabh Lathia, Heikki Linnakangas)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        允许并行构建btree索引 (Peter Geoghegan, Rushabh Lathia, Heikki Linnakangas)
        </para>
       </listitem>
 
@@ -2709,9 +3972,14 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2017-12-21 [180428404] Add parallel-aware hash joins.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow hash joins to be performed in parallel using a shared hash
         table (Thomas Munro)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        允许使用共享哈希表并行执行哈希连接 (Thomas Munro)
        </para>
       </listitem>
 
@@ -2721,11 +3989,16 @@ Branch: REL9_3_STABLE [84261eb10] 2018-10-19 17:02:26 -0400
 2018-03-22 [88ba0ae2a] Consider Parallel Append of partial paths for UNION [ALL
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow <literal>UNION</literal> to run each
         <command>SELECT</command> in parallel if the individual
         <command>SELECT</command>s cannot be parallelized (Amit Khandekar,
         Robert Haas, Amul Sul)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        允许<literal>UNION</literal>并行运行每个<command>SELECT</command>，如果单个<command>SELECT</command>无法并行化的话 (Amit Khandekar, Robert Haas, Amul Sul)
        </para>
       </listitem>
 
@@ -2736,9 +4009,14 @@ same commits as above
 2018-03-22 [88ba0ae2a] Consider Parallel Append of partial paths for UNION [ALL
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow partition scans to more efficiently use parallel workers
         (Amit Khandekar, Robert Haas, Amul Sul)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        允许使用并行工作者进行更有效的分区扫描 (Amit Khandekar, Robert Haas, Amul Sul)
        </para>
       </listitem>
 
@@ -2747,14 +4025,24 @@ same commits as above
 2017-08-29 [3452dc524] Push tuple limits through Gather and Gather Merge.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow <literal>LIMIT</literal> to be passed to parallel workers
         (Robert Haas, Tom Lane)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许将<literal>LIMIT</literal>传给并行工作者 (Robert Haas, Tom Lane)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This allows workers to reduce returned results and use targeted
         index scans.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        这样允许工作者减少返回结果，使用有针对性的索引扫描。
        </para>
       </listitem>
 
@@ -2765,10 +4053,15 @@ same commits as above
 2018-03-29 [11cf92f6e] Rewrite the code that applies scan/join targets to paths
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow single-evaluation queries, e.g. <literal>WHERE</literal>
         clause aggregate queries, and functions in the target list to be
         parallelized (Amit Kapila, Robert Haas)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        允许单次评估查询，例如<literal>WHERE</literal>子句聚集查询和目标列表中的函数并行化 (Amit Kapila, Robert Haas)
        </para>
       </listitem>
 
@@ -2777,14 +4070,24 @@ same commits as above
 2017-11-15 [e5253fdc4] Add parallel_leader_participation GUC.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add server parameter <link
         linkend="guc-parallel-leader-participation"><varname>parallel_leader_participation</varname></link>
         to control whether the leader also executes subplans (Thomas Munro)
        </para>
+____________________________________________________________________________-->
+       <para>
+        增加服务器参数<link linkend="guc-parallel-leader-participation"><varname>parallel_leader_participation</varname></link>用来控制领导者是否执行子计划 (Thomas Munro)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         The default is enabled, meaning the leader will execute subplans.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        缺省启用，意味着领导者要执行子计划。
        </para>
       </listitem>
 
@@ -2793,10 +4096,15 @@ same commits as above
 2017-10-05 [e9baa5e9f] Allow DML commands that create tables to use parallel qu
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow parallelization of commands <command>CREATE TABLE
         ... AS</command>, <command>SELECT INTO</command>, and
         <command>CREATE MATERIALIZED VIEW</command> (Haribabu Kommi)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        允许命令<command>CREATE TABLE ... AS</command>, <command>SELECT INTO</command>和<command>CREATE MATERIALIZED VIEW</command>并行化 (Haribabu Kommi)
        </para>
       </listitem>
 
@@ -2806,9 +4114,14 @@ same commits as above
 
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Improve performance of sequential scans with many parallel workers
         (David Rowley)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        改进有许多并行工作者时顺序扫描的性能 (David Rowley)
        </para>
       </listitem>
 
@@ -2817,9 +4130,14 @@ same commits as above
 2017-08-29 [bf11e7ee2] Propagate sort instrumentation from workers back to lead
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add reporting of parallel workers' sort activity in
         <command>EXPLAIN</command> (Robert Haas, Tom Lane)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        在<command>EXPLAIN</command>中增加并行工作者排序活动的报告 (Robert Haas, Tom Lane)
        </para>
 
       </listitem>
@@ -2829,7 +4147,10 @@ same commits as above
     </sect4>
 
     <sect4>
+<!--==========================orignal english content==========================
      <title>Indexes</title>
+____________________________________________________________________________-->
+     <title>索引</title>
 
      <itemizedlist>
 
@@ -2838,19 +4159,29 @@ same commits as above
 2018-04-07 [8224de4f4] Indexes with INCLUDE columns and their support in B-tree
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow B-tree indexes to include columns that are not part of the
         search key or unique constraint, but are available to be read by
         index-only scans (Anastasia Lubennikova, Alexander Korotkov, Teodor
         Sigaev)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许B-树索引包含不是搜索键或唯一约束的，但可用于仅索引扫描读的列 (Anastasia Lubennikova, Alexander Korotkov, Teodor Sigaev)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This is enabled by the new <literal>INCLUDE</literal> clause of <link
         linkend="sql-createindex"><command>CREATE INDEX</command></link>.
         It facilitates building <quote>covering indexes</quote> that optimize
         specific types of queries.  Columns can be included even if their
         data types don't have B-tree support.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        该功能可用<link linkend="sql-createindex"><command>CREATE INDEX</command></link>的新的<literal>INCLUDE</literal>子句来启用。它利用构造“覆盖索引”来优化特定类型的查询。可包含一些列，即使其数据类型B-树不支持。
        </para>
       </listitem>
 
@@ -2860,9 +4191,14 @@ same commits as above
 2018-04-10 [074251db6] Adjustments to the btree fastpath optimization.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Improve performance of monotonically increasing index additions
         (Pavan Deolasee, Peter Geoghegan)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        改进索引不断增长时的性能 (Pavan Deolasee, Peter Geoghegan)
        </para>
       </listitem>
 
@@ -2871,8 +4207,13 @@ same commits as above
 2017-09-22 [7c75ef571] hash: Implement page-at-a-time scan.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Improve performance of hash index scans (Ashutosh Sharma)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        改进哈希索引扫描的性能 (Ashutosh Sharma)
        </para>
       </listitem>
 
@@ -2883,20 +4224,33 @@ same commits as above
 2018-04-07 [b508a56f2] Predicate locking in hash indexes.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add predicate locking for hash, GiST and GIN indexes (Shubham
         Barai)
        </para>
+____________________________________________________________________________-->
+       <para>
+        为哈希、GiST和GIN索引添加谓词锁 (Shubham Barai)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This reduces the likelihood of serialization conflicts in
         serializable-mode transactions.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        这样减少了序列化模式事务中序列化冲突的可能性。
        </para>
       </listitem>
 
      </itemizedlist>
 
      <sect5>
+<!--==========================orignal english content==========================
+      <title><link linkend="spgist">SP-Gist</link></title>
+____________________________________________________________________________-->
       <title><link linkend="spgist">SP-Gist</link></title>
 
       <itemizedlist>
@@ -2906,15 +4260,26 @@ same commits as above
 2018-04-03 [710d90da1] Add prefix operator for TEXT type.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add prefix-match
         operator <type>text</type> <literal>^@</literal> <type>text</type>,
         which is supported by SP-GiST (Ildus Kurbangaliev)
        </para>
+____________________________________________________________________________-->
+       <para>
+        增加前缀匹配操作符<type>text</type> <literal>^@</literal> <type>text</type>，由SP-GiST支持此项功能 (Ildus Kurbangaliev)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This is similar to using <replaceable>var</replaceable> <literal>LIKE
         'word%'</literal> with a btree index, but it is more efficient.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        这类似于btree索引时使用<replaceable>var</replaceable> <literal>LIKE
+        'word%'</literal>，但它更有效。
        </para>
       </listitem>
 
@@ -2923,9 +4288,14 @@ same commits as above
 2017-12-25 [ff963b393] Add polygon opclass for SP-GiST
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow polygons to be indexed with SP-GiST (Nikita Glukhov,
         Alexander Korotkov)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        允许使用SP-GiST索引多边形。(Nikita Glukhov, Alexander Korotkov)
        </para>
       </listitem>
 
@@ -2934,9 +4304,14 @@ same commits as above
 2017-12-22 [854823fa3] Add optional compression method to SP-GiST
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow SP-GiST to use lossy representation of leaf keys (Teodor Sigaev,
         Heikki Linnakangas, Alexander Korotkov, Nikita Glukhov)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        允许SP-GiST使用叶子键的有损表示 (Teodor Sigaev, Heikki Linnakangas, Alexander Korotkov, Nikita Glukhov)
        </para>
 
       </listitem>
@@ -2948,7 +4323,10 @@ same commits as above
     </sect4>
 
     <sect4>
+<!--==========================orignal english content==========================
      <title>Optimizer</title>
+____________________________________________________________________________-->
+     <title>优化器</title>
 
      <itemizedlist>
 
@@ -2957,11 +4335,17 @@ same commits as above
 2018-03-22 [b5db1d93d] Improve ANALYZE's strategy for finding MCVs.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Improve selection of the most common values for statistics
         (Jeff Janes, Dean Rasheed)
        </para>
+____________________________________________________________________________-->
+       <para>
+        改进统计信息最频值的选择 (Jeff Janes, Dean Rasheed)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Previously, the most common values (<acronym>MCV</acronym>s) were
         identified based on their frequency compared to all column
@@ -2970,6 +4354,10 @@ same commits as above
         This improves the robustness of the algorithm for both uniform and
         non-uniform distributions.
        </para>
+____________________________________________________________________________-->
+       <para>
+        以前，最频值(<acronym>MCV</acronym>)的标识是基于他们与所有列值比较的频度。现在MCV的选择是基于他们与非MCV值比较的频度。这样就改进了均匀和不均匀分布下的算法的健壮性。
+       </para>
       </listitem>
 
       <listitem>
@@ -2977,17 +4365,27 @@ same commits as above
 2017-09-13 [7d08ce286] Distinguish selectivity of &lt; from &lt;= and &gt; from &gt;=.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Improve selectivity estimates for <literal>&gt;=</literal>
         and <literal>&lt;=</literal> (Tom Lane)
        </para>
+____________________________________________________________________________-->
+       <para>
+        改进<literal>&gt;=</literal>和<literal>&lt;=</literal>的选择性评估 (Tom Lane)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Previously, such cases used the same selectivity estimates
         as <literal>&gt;</literal> and <literal>&lt;</literal>, respectively,
         unless the comparison constants are <acronym>MCV</acronym>s.
         This change is particularly helpful for queries
         involving <literal>BETWEEN</literal> with small ranges.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        以前，此类案例如<literal>&gt;</literal>和<literal>&lt;</literal>分别使用同样的选择性评估，除非比较常数是<acronym>MCV</acronym>。该变化对使用<literal>BETWEEN</literal>在小区间查询特别有用。
        </para>
       </listitem>
 
@@ -2996,15 +4394,25 @@ same commits as above
 2017-10-08 [8ec5429e2] Reduce "X = X" to "X IS NOT NULL", if it's easy to do so
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Reduce <replaceable>var</replaceable> <literal>=</literal>
         <replaceable>var</replaceable>
         to <replaceable>var</replaceable> <literal>IS NOT NULL</literal>
         where equivalent (Tom Lane)
        </para>
+____________________________________________________________________________-->
+       <para>
+        在等效的地方将<replaceable>var</replaceable> <literal>=</literal><replaceable>var</replaceable>简化为<replaceable>var</replaceable> <literal>IS NOT NULL</literal> (Tom Lane)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This leads to better selectivity estimates.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        这会带来更好的选择性评估。
        </para>
       </listitem>
 
@@ -3013,9 +4421,14 @@ same commits as above
 2017-11-29 [7ca25b7de] Fix neqjoinsel's behavior for semi/anti join cases.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Improve optimizer's row count estimates for <literal>EXISTS</literal>
         and <literal>NOT EXISTS</literal> queries (Tom Lane)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        改进优化器对<literal>EXISTS</literal>和<literal>NOT EXISTS</literal>查询的行计数估计 (Tom Lane)
        </para>
       </listitem>
 
@@ -3024,9 +4437,14 @@ same commits as above
 2017-11-02 [7b6c07547] Teach planner to account for HAVING quals in aggregation
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Make the optimizer account for evaluation costs and selectivity
         of <literal>HAVING</literal> clauses (Tom Lane)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        使优化器负责评估代价和<literal>HAVING</literal>子句的选择性 (Tom Lane)
        </para>
 
       </listitem>
@@ -3036,7 +4454,10 @@ same commits as above
     </sect4>
 
     <sect4>
+<!--==========================orignal english content==========================
      <title>General Performance</title>
+____________________________________________________________________________-->
+     <title>一般性能</title>
 
      <itemizedlist>
 
@@ -3051,16 +4472,26 @@ same commits as above
 2018-09-15 [0fdadfb01] In v11, disable JIT by default (it's still enabled by de
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add <link linkend="jit">Just-in-Time</link>
         (<acronym>JIT</acronym>) compilation of some parts of query plans
         to improve execution speed (Andres Freund)
        </para>
+____________________________________________________________________________-->
+       <para>
+        增加对查询计划的某些部分的<link linkend="jit">即时</link>(<acronym>JIT</acronym>)编译，以改进执行性能 (Andres Freund)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This feature requires <application>LLVM</application> to be
         available.  It is not currently enabled by default, even in
         builds that support it.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        该特性需<application>LLVM</application>可用。当前不是默认启用，即使在构建中支持也不是。
        </para>
       </listitem>
 
@@ -3069,9 +4500,14 @@ same commits as above
 2017-11-01 [7c70996eb] Allow bitmap scans to operate as index-only scans when p
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow bitmap scans to perform index-only scans when possible
         (Alexander Kuzmenkov)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        允许在可能时位图扫描执行仅索引扫描 (Alexander Kuzmenkov)
        </para>
       </listitem>
 
@@ -3081,13 +4517,23 @@ same commits as above
 2018-03-30 [c79f6df75] Do index FSM vacuuming sooner.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Update the free space map during <command>VACUUM</command>
         (Claudio Freire)
        </para>
+____________________________________________________________________________-->
+       <para>
+        更新<command>VACUUM</command>时空闲空间映射 (Claudio Freire)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This allows free space to be reused more quickly.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        这样允许空闲空间能更快地重用。
        </para>
       </listitem>
 
@@ -3096,9 +4542,14 @@ same commits as above
 2018-04-04 [857f9c36c] Skip full index scan during cleanup of B-tree indexes wh
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow <command>VACUUM</command> to avoid unnecessary index scans
         (Masahiko Sawada, Alexander Korotkov)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        允许<command>VACUUM</command>避免不必要的索引扫描 (Masahiko Sawada, Alexander Korotkov)
        </para>
       </listitem>
 
@@ -3107,9 +4558,14 @@ same commits as above
 2017-09-01 [baaf272ac] Use group updates when setting transaction status in clo
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Improve performance of committing multiple concurrent transactions
         (Amit Kapila)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        改进多并发事务的提交性能 (Amit Kapila)
        </para>
       </listitem>
 
@@ -3118,9 +4574,14 @@ same commits as above
 2017-10-08 [84ad4b036] Reduce memory usage of targetlist SRFs.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Reduce memory usage for queries using set-returning functions in
         their target lists (Andres Freund)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        减少那些在目标列表中使用集返回函数的查询的内存使用 (Andres Freund)
        </para>
       </listitem>
 
@@ -3129,8 +4590,13 @@ same commits as above
 2018-01-09 [69c3936a1] Expression evaluation based aggregate transition invocat
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Improve the speed of aggregate computations (Andres Freund)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        改进聚集计算的速度 (Andres Freund)
        </para>
       </listitem>
 
@@ -3139,16 +4605,26 @@ same commits as above
 2018-02-07 [1bc0100d2] postgres_fdw: Push down UPDATE/DELETE joins to remote se
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow <link
         linkend="postgres-fdw"><filename>postgres_fdw</filename></link>
         to push <command>UPDATE</command>s and <command>DELETE</command>s
         using joins to foreign servers (Etsuro Fujita)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许<link linkend="postgres-fdw"><filename>postgres_fdw</filename></link>将使用连接的<command>UPDATE</command>和<command>DELETE</command>命令推送到外部服务器 (Etsuro Fujita)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Previously, only non-join <command>UPDATE</command>s and
         <command>DELETE</command>s were pushed.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        以前，仅推送非连接的<command>UPDATE</command>和<command>DELETE</command>命令。
        </para>
 
       </listitem>
@@ -3158,15 +4634,25 @@ same commits as above
 2018-01-21 [1cc4f536e] Support huge pages on Windows
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add support for <firstterm>large pages</firstterm> on Windows
         (Takayuki Tsunakawa, Thomas Munro)
        </para>
+____________________________________________________________________________-->
+       <para>
+        增加Windows上的<firstterm>大页</firstterm>支持 (Takayuki Tsunakawa, Thomas Munro)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This is controlled by the <link
         linkend="guc-huge-pages">huge_pages</link> configuration
         parameter.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        该功能由<link linkend="guc-huge-pages">huge_pages</link>配置参数来控制。
        </para>
       </listitem>
 
@@ -3175,7 +4661,10 @@ same commits as above
     </sect4>
 
     <sect4>
+<!--==========================orignal english content==========================
      <title>Monitoring</title>
+____________________________________________________________________________-->
+     <title>监控</title>
 
      <itemizedlist>
 
@@ -3184,6 +4673,7 @@ same commits as above
 2017-09-01 [c039ba071] Add memory info to getrusage output
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Show memory usage in output from <link
         linkend="runtime-config-statistics-monitor"><varname>log_statement_stats</varname></link>,
@@ -3192,6 +4682,10 @@ same commits as above
         <varname>log_executor_stats</varname> (Justin Pryzby, Peter
         Eisentraut)
        </para>
+____________________________________________________________________________-->
+       <para>
+        在<link linkend="runtime-config-statistics-monitor"><varname>log_statement_stats</varname></link>,<varname>log_parser_stats</varname>,<varname>log_planner_stats</varname>和<varname>log_executor_stats</varname>的输出中显示内存使用情况 (Justin Pryzby, Peter Eisentraut)
+       </para>
       </listitem>
 
       <listitem>
@@ -3199,14 +4693,24 @@ same commits as above
 2017-09-29 [5373bc2a0] Add background worker type
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add column <link
         linkend="pg-stat-activity-view"><structname>pg_stat_activity</structname>.<structfield>backend_type</structfield></link>
         to show the type of a background worker (Peter Eisentraut)
        </para>
+____________________________________________________________________________-->
+       <para>
+        增加<link linkend="pg-stat-activity-view"><structname>pg_stat_activity</structname>.<structfield>backend_type</structfield></link>列以显示后台工作者类型 (Peter Eisentraut)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         The type is also visible in <application>ps</application> output.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        该类型在<application>ps</application>输出中也可见。
        </para>
       </listitem>
 
@@ -3215,11 +4719,16 @@ same commits as above
 2017-12-04 [ab6eaee88] When VACUUM or ANALYZE skips a concurrently dropped tabl
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Make <link
         linkend="guc-log-autovacuum-min-duration"><varname>log_autovacuum_min_duration</varname></link>
         log skipped tables that are concurrently being dropped (Nathan
         Bossart)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        使<link linkend="guc-log-autovacuum-min-duration"><varname>log_autovacuum_min_duration</varname></link>记录那些被同时删除而忽略掉的表 (Nathan Bossart)
        </para>
 
       </listitem>
@@ -3227,7 +4736,10 @@ same commits as above
      </itemizedlist>
 
      <sect5>
+<!--==========================orignal english content==========================
       <title><link linkend="infoschema-tables">Information Schema</link></title>
+____________________________________________________________________________-->
+      <title><link linkend="infoschema-tables">信息模式</link></title>
 
       <itemizedlist>
 
@@ -3236,11 +4748,17 @@ same commits as above
 2018-02-07 [32ff26911] Add more information_schema columns
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add <literal>information_schema</literal> columns related to table
         constraints and triggers (Peter Eisentraut)
        </para>
+____________________________________________________________________________-->
+       <para>
+        增加与表约束和触发器相关的<literal>information_schema</literal>列 (Peter Eisentraut)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Specifically,
         <structname>triggers</structname>.<structfield>action_order</structfield>,
@@ -3251,6 +4769,10 @@ same commits as above
         <structname>table_constraints</structname>.<structfield>enforced</structfield>
         now exists but is not yet usefully populated.
        </para>
+____________________________________________________________________________-->
+       <para>
+        特别是现在<structname>triggers</structname>.<structfield>action_order</structfield>,<structname>triggers</structname>.<structfield>action_reference_old_table</structfield>和<structname>triggers</structname>.<structfield>action_reference_new_table</structfield>都填有数据，而以前则总为空。此外，现在<structname>table_constraints</structname>.<structfield>enforced</structfield>虽然存在，但仍未填入有用数据。
+       </para>
 
       </listitem>
 
@@ -3260,7 +4782,10 @@ same commits as above
     </sect4>
 
     <sect4>
+<!--==========================orignal english content==========================
      <title><acronym>Authentication</acronym></title>
+____________________________________________________________________________-->
+     <title><acronym>认证</acronym></title>
 
      <itemizedlist>
 
@@ -3269,15 +4794,25 @@ same commits as above
 2017-09-12 [83aaac41c] Allow custom search filters to be configured for LDAP au
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow the server to specify more complex <link
         linkend="auth-ldap"><acronym>LDAP</acronym></link> specifications
         in search+bind mode (Thomas Munro)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许服务器在搜索+绑定模式中指定更为复杂的<link linkend="auth-ldap"><acronym>LDAP</acronym></link>规格要求 (Thomas Munro)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Specifically, <literal>ldapsearchfilter</literal> allows pattern matching using
         combinations of <acronym>LDAP</acronym> attributes.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        特别是<literal>ldapsearchfilter</literal>允许使用<acronym>LDAP</acronym>属性组合进行模式匹配。
        </para>
       </listitem>
 
@@ -3287,11 +4822,17 @@ same commits as above
 2018-01-04 [3ad2afc2e] Define LDAPS_PORT if it's missing and disable implicit L
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow <acronym>LDAP</acronym> authentication to use
         encrypted <acronym>LDAP</acronym> (Thomas Munro)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许<acronym>LDAP</acronym>认证使用加密的<acronym>LDAP</acronym> (Thomas Munro)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         We already supported <acronym>LDAP</acronym> over
         <acronym>TLS</acronym> by using <literal>ldaptls=1</literal>.
@@ -3300,6 +4841,10 @@ same commits as above
         with <literal>ldapscheme=ldaps</literal>
         or <literal>ldapurl=ldaps://</literal>.
        </para>
+____________________________________________________________________________-->
+       <para>
+        我们已经支持<acronym>TLS</acronym>上的<acronym>LDAP</acronym>，这通过用<literal>ldaptls=1</literal>来实现。新的<acronym>TLS</acronym> <acronym>LDAP</acronym>是加密<acronym>LDAP</acronym>，用<literal>ldapscheme=ldaps</literal>或<literal>ldapurl=ldaps://</literal>来启用。
+       </para>
       </listitem>
 
       <listitem>
@@ -3307,8 +4852,13 @@ same commits as above
 2017-10-12 [cf1238cd9] Log diagnostic messages if errors occur during LDAP auth
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Improve logging of <acronym>LDAP</acronym> errors (Thomas Munro)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        改进<acronym>LDAP</acronym>错误日志(Thomas Munro)
        </para>
 
       </listitem>
@@ -3318,7 +4868,10 @@ same commits as above
     </sect4>
 
     <sect4>
+<!--==========================orignal english content==========================
      <title>Permissions</title>
+____________________________________________________________________________-->
+     <title>权限</title>
 
      <itemizedlist>
 
@@ -3328,11 +4881,17 @@ same commits as above
 2018-04-07 [da9b580d8] Refactor dir/file permissions
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add <link linkend="default-roles-table">default roles</link> that
         enable file system access (Stephen Frost)
        </para>
+____________________________________________________________________________-->
+       <para>
+        增加启用文件系统访问的<link linkend="default-roles-table">默认角色</link> (Stephen Frost)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Specifically, the new roles are:
         <literal>pg_read_server_files</literal>,
@@ -3343,6 +4902,10 @@ same commits as above
         Previously, only superusers could use these functions, and that
         is still the default behavior.
        </para>
+____________________________________________________________________________-->
+       <para>
+        特别地，这些新角色是：<literal>pg_read_server_files</literal>,<literal>pg_write_server_files</literal>和<literal>pg_execute_server_program</literal>。这些角色现在还控制着谁可以使用服务器端<command>COPY</command>和<link linkend="file-fdw"><filename>file_fdw</filename></link>扩展。以前，仅超级用户才能使用这些功能，这仍然是默认行为。
+       </para>
       </listitem>
 
       <listitem>
@@ -3350,18 +4913,28 @@ same commits as above
 2018-04-06 [e79350fef] Remove explicit superuser checks in favor of ACLs
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow access to file system functions to be controlled by
         <command>GRANT</command>/<command>REVOKE</command> permissions,
         rather than superuser checks (Stephen Frost)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许用<command>GRANT</command>/<command>REVOKE</command>权限许可来控制文件系统函数的访问，而不是由超级用户检查来控制 (Stephen Frost)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Specifically, these functions were modified: <link
         linkend="functions-admin-genfile-table"><function>pg_ls_dir()</function></link>,
         <function>pg_read_file()</function>,
         <function>pg_read_binary_file()</function>,
         <function>pg_stat_file()</function>.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        特别地，修改了这些函数：<link linkend="functions-admin-genfile-table"><function>pg_ls_dir()</function></link>,<function>pg_read_file()</function>,<function>pg_read_binary_file()</function>,<function>pg_stat_file()</function>。
        </para>
       </listitem>
 
@@ -3371,20 +4944,35 @@ same commits as above
 2017-11-14 [6d776522d] Document changes in large-object privilege checking.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Use <command>GRANT</command>/<command>REVOKE</command>
         to control access to <link
         linkend="lo-import"><function>lo_import()</function></link>
         and <function>lo_export()</function> (Michael Paquier, Tom Lane)
        </para>
+____________________________________________________________________________-->
+       <para>
+        使用<command>GRANT</command>/<command>REVOKE</command>控制对<link linkend="lo-import"><function>lo_import()</function></link>和<function>lo_export()</function>的访问 (Michael Paquier, Tom Lane)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Previously, only superusers were granted access to these functions.
        </para>
+____________________________________________________________________________-->
+       <para>
+        以前，仅超级用户才有权访问这些函数。
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         The compile-time option <literal>ALLOW_DANGEROUS_LO_FUNCTIONS</literal>
         has been removed.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        编译时选项<literal>ALLOW_DANGEROUS_LO_FUNCTIONS</literal>已被移除。
        </para>
       </listitem>
 
@@ -3393,19 +4981,29 @@ same commits as above
 2017-12-05 [ab3f008a2] postgres_fdw: Judge password use by run-as user, not ses
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Use view owner not session owner when
         preventing non-password access to <link
         linkend="postgres-fdw"><filename>postgres_fdw</filename></link>
         tables (Robert Haas)
        </para>
+____________________________________________________________________________-->
+       <para>
+        防止对<link linkend="postgres-fdw"><filename>postgres_fdw</filename></link>表进行无密码访问时，使用视图拥有者而非会话拥有者 (Robert Haas)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         <productname>PostgreSQL</productname> only allows superusers to
         access <filename>postgres_fdw</filename> tables without
         passwords, e.g. via <literal>peer</literal>.  Previously, the
         session owner had to be a superuser to allow such access; now
         the view owner is checked instead.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        <productname>PostgreSQL</productname>仅允许超级用户对<filename>postgres_fdw</filename>表进行无密码的访问，例如通过<literal>peer</literal>访问。以前，会话拥有者必须为超级用户才允许访问；现在以检查视图拥有者代之。
        </para>
       </listitem>
 
@@ -3414,9 +5012,14 @@ same commits as above
 2018-04-14 [50c6bb022] Fix enforcement of SELECT FOR UPDATE permissions with ne
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Fix invalid locking permission check in <command>SELECT FOR
         UPDATE</command> on views (Tom Lane)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        修复视图上<command>SELECT FOR UPDATE</command>的无效的锁权限检查问题 (Tom Lane)
        </para>
 
       </listitem>
@@ -3426,7 +5029,10 @@ same commits as above
     </sect4>
 
     <sect4>
+<!--==========================orignal english content==========================
      <title>Server Configuration</title>
+____________________________________________________________________________-->
+     <title>服务器配置</title>
 
      <itemizedlist>
 
@@ -3435,19 +5041,29 @@ same commits as above
 2018-03-17 [8a3d94252] Add ssl_passphrase_command setting
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add server setting <link
         linkend="guc-ssl-passphrase-command"><varname>ssl_passphrase_command</varname></link>
         to allow supplying of the passphrase for <acronym>SSL</acronym>
         key files (Peter Eisentraut)
        </para>
+____________________________________________________________________________-->
+       <para>
+        增加服务器参数<link linkend="guc-ssl-passphrase-command"><varname>ssl_passphrase_command</varname></link>以允许提供<acronym>SSL</acronym>密钥文件的密语 (Peter Eisentraut)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Also add <link
         linkend="guc-ssl-passphrase-command-supports-reload"><varname>ssl_passphrase_command_supports_reload</varname></link>
         to specify whether the <acronym>SSL</acronym> configuration
         should be reloaded and <varname>ssl_passphrase_command</varname>
         called during a server configuration reload.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        此外增加<link linkend="guc-ssl-passphrase-command-supports-reload"><varname>ssl_passphrase_command_supports_reload</varname></link>以详细说明<acronym>SSL</acronym>配置是否应重新载入，且服务器配置重新载入时是否调用<varname>ssl_passphrase_command</varname>。
        </para>
       </listitem>
 
@@ -3456,16 +5072,26 @@ same commits as above
 2017-11-20 [c2513365a] Parameter toast_tuple_target controls TOAST for new rows
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add storage parameter <link
         linkend="sql-createtable-storage-parameters"><varname>toast_tuple_target</varname></link>
         to control the minimum tuple length before <acronym>TOAST</acronym>
         storage will be considered (Simon Riggs)
        </para>
+____________________________________________________________________________-->
+       <para>
+        增加存储参数<link linkend="sql-createtable-storage-parameters"><varname>toast_tuple_target</varname></link>，以在考虑用<acronym>TOAST</acronym>存储前控制最小的元组长度 (Simon Riggs)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         The default <acronym>TOAST</acronym> threshold has not been
         changed.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        缺省的<acronym>TOAST</acronym>阈值不变。
        </para>
       </listitem>
 
@@ -3475,15 +5101,25 @@ same commits as above
 2018-05-23 [b06d8e58b] Accept "B" in all memory-unit GUCs, and improve error me
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow server options related to memory and file sizes to be
         specified in units of bytes (Beena Emerson)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许以字节为单位制定内存和文件大小相关的服务器选项 (Beena Emerson)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         The new unit suffix is <quote>B</quote>.  This is in addition to the
         existing units <quote>kB</quote>, <quote>MB</quote>, <quote>GB</quote>
         and <quote>TB</quote>.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        新单位后缀为<quote>B</quote>。另外已有的单位是<quote>kB</quote>, <quote>MB</quote>, <quote>GB</quote>和<quote>TB</quote>。
        </para>
 
       </listitem>
@@ -3493,7 +5129,10 @@ same commits as above
     </sect4>
 
     <sect4>
+<!--==========================orignal english content==========================
      <title><link linkend="wal">Write-Ahead Log</link> (<acronym>WAL</acronym>)</title>
+____________________________________________________________________________-->
+     <title><link linkend="wal">预写日志</link> (<acronym>WAL</acronym>)</title>
 
      <itemizedlist>
 
@@ -3502,13 +5141,23 @@ same commits as above
 2017-09-19 [fc49e24fa] Make WAL segment size configurable at initdb time.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow the <acronym>WAL</acronym> file size to be set
         during <application>initdb</application> (Beena Emerson)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许<application>initdb</application>时设置<acronym>WAL</acronym>文件大小 (Beena Emerson)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Previously, the 16MB default could only be changed at compile time.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        以前，缺省值16MB只能在编译时改变。
        </para>
       </listitem>
 
@@ -3517,13 +5166,23 @@ same commits as above
 2017-11-07 [4b0d28de0] Remove secondary checkpoint
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Retain <acronym>WAL</acronym> data for only a single checkpoint
         (Simon Riggs)
        </para>
+____________________________________________________________________________-->
+       <para>
+        仅为单个检查点保留<acronym>WAL</acronym>数据 (Simon Riggs)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Previously, <acronym>WAL</acronym> was retained for two checkpoints.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        以前，为两个检查点保留<acronym>WAL</acronym>。
        </para>
       </listitem>
 
@@ -3532,10 +5191,15 @@ same commits as above
 2018-03-30 [4a33bb59d] Ensure that WAL pages skipped by a forced WAL switch are
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Fill the unused portion of force-switched <acronym>WAL</acronym>
         segment files with zeros for improved compressibility (Chapman
         Flack)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        为提高压缩率，以零填充强制切换的<acronym>WAL</acronym>段文件的未使用部分 (Chapman Flack)
        </para>
 
       </listitem>
@@ -3547,7 +5211,10 @@ same commits as above
    </sect3>
 
    <sect3>
+<!--==========================orignal english content==========================
     <title>Base Backup and Streaming Replication</title>
+____________________________________________________________________________-->
+    <title>库备份和流复制</title>
 
     <itemizedlist>
 
@@ -3557,9 +5224,14 @@ same commits as above
 2018-04-07 [039eb6e92] Logical replication support for TRUNCATE
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Replicate <command>TRUNCATE</command> activity when using logical
         replication (Simon Riggs, Marco Nenciarini, Peter Eisentraut)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        使用流复制时，复制<command>TRUNCATE</command>活动 (Simon Riggs, Marco Nenciarini, Peter Eisentraut)
        </para>
       </listitem>
 
@@ -3568,9 +5240,14 @@ same commits as above
 2018-03-28 [1eb6d6527] Store 2PC GID in commit/abort WAL recs for logical decod
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Pass prepared transaction information to logical replication
         subscribers (Nikhil Sontakke, Stas Kelvich)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        将准备事务信息传给逻辑复制订阅者 (Nikhil Sontakke, Stas Kelvich)
        </para>
       </listitem>
 
@@ -3581,14 +5258,24 @@ same commits as above
 2017-11-07 [98267ee83] Exclude pg_internal.init from BASE_BACKUP
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Exclude unlogged tables, temporary tables, and
         <filename>pg_internal.init</filename> files from streaming base
         backups (David Steele)
        </para>
+____________________________________________________________________________-->
+       <para>
+        将非日志表、临时表和<filename>pg_internal.init</filename>文件从流式库备份中排除 (David Steele)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         There is no need to copy such files.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        没有必要拷贝这些文件。
        </para>
       </listitem>
 
@@ -3597,9 +5284,14 @@ same commits as above
 2018-04-03 [4eb77d50c] Validate page level checksums in base backups
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow checksums of heap pages to be verified during streaming base
         backup (Michael Banck)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        允许在流式库备份时验证堆页面的校验和 (Michael Banck)
        </para>
       </listitem>
 
@@ -3608,15 +5300,25 @@ same commits as above
 2018-01-17 [9c7d06d60] Ability to advance replication slots
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow replication slots to be advanced programmatically, rather
         than be consumed by subscribers (Petr Jelinek)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许复制槽以编程方式前进，而不是被订阅者消费 (Petr Jelinek)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This allows efficient advancement of replication slots when the
         contents do not need to be consumed.  This is performed by
         <function>pg_replication_slot_advance()</function>.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        这样允许在没必要消费内容时，复制槽有效前进。此功能通过<function>pg_replication_slot_advance()</function>实现。
        </para>
       </listitem>
 
@@ -3625,15 +5327,25 @@ same commits as above
 2018-01-06 [6271fceb8] Add TIMELINE to backup_label file
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add timeline information to the <link
         linkend="backup-lowlevel-base-backup"><filename>backup_label</filename></link>
         file (Michael Paquier)
        </para>
+____________________________________________________________________________-->
+       <para>
+        将时间线信息加到<link linkend="backup-lowlevel-base-backup"><filename>backup_label</filename></link>文件中 (Michael Paquier)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Also add a check that the <acronym>WAL</acronym> timeline matches
         the <filename>backup_label</filename> file's timeline.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        另增<acronym>WAL</acronym>时间线与<filename>backup_label</filename>匹配的检查。
        </para>
       </listitem>
 
@@ -3642,10 +5354,15 @@ same commits as above
 2018-03-31 [9a895462d] Enhance pg_stat_wal_receiver view to display host and po
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add host and port connection information to the
         <structname>pg_stat_wal_receiver</structname> system view
         (Haribabu Kommi)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        将主机和端口连接信息加到<structname>pg_stat_wal_receiver</structname>系统视图中 (Haribabu Kommi)
        </para>
       </listitem>
 
@@ -3654,7 +5371,10 @@ same commits as above
    </sect3>
 
    <sect3>
+<!--==========================orignal english content==========================
     <title>Utility Commands</title>
+____________________________________________________________________________-->
+    <title>实用工具命令</title>
 
     <itemizedlist>
 
@@ -3663,14 +5383,24 @@ same commits as above
 2018-03-28 [16828d5c0] Fast ALTER TABLE ADD COLUMN with a non-NULL default
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow <command>ALTER TABLE</command> to add a column with
         a non-null default without doing a table rewrite (Andrew Dunstan,
         Serge Rielau)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许<command>ALTER TABLE</command>用非空缺省值添加列，而不需重写表 (Andrew Dunstan, Serge Rielau)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This is enabled when the default value is a constant.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        当缺省值为常数时启用该项功能。
        </para>
       </listitem>
 
@@ -3680,9 +5410,14 @@ same commits as above
 2018-03-31 [1b26bd408] Fix bug with view locking code.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow views to be locked by locking the underlying tables
         (Yugo Nagata)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        允许用视图所基于的表来锁定视图 (Yugo Nagata)
        </para>
       </listitem>
 
@@ -3691,14 +5426,24 @@ same commits as above
 2017-09-06 [5b6d13eec] Allow SET STATISTICS on expression indexes
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow <command>ALTER INDEX</command> to set statistics-gathering
         targets for expression indexes (Alexander Korotkov, Adrien Nayrat)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许<command>ALTER INDEX</command>为表达式索引设置统计信息收集目标 (Alexander Korotkov, Adrien Nayrat)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         In <application>psql</application>, <literal>\d+</literal> now shows
         the statistics target for indexes.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        在<application>psql</application>中，<literal>\d+</literal>现在显示索引的统计信息目标。
        </para>
       </listitem>
 
@@ -3707,17 +5452,27 @@ same commits as above
 2017-10-03 [11d8d72c2] Allow multiple tables to be specified in one VACUUM or A
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow multiple tables to be specified in one
         <command>VACUUM</command> or <command>ANALYZE</command> command
         (Nathan Bossart)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许一条<command>VACUUM</command>或<command>ANALYZE</command>命令中指定多个表 (Nathan Bossart)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Also, if any table mentioned in <command>VACUUM</command> uses
         a column list, then the <command>ANALYZE</command> keyword must be
         supplied; previously, <command>ANALYZE</command> was implied in
         such cases.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        此外，<command>VACUUM</command>中提及的任何表若使用列（字段）列表，则必须提供<command>ANALYZE</command>关键词；以前此类情况下<command>ANALYZE</command>是隐含在内的。
        </para>
       </listitem>
 
@@ -3726,14 +5481,24 @@ same commits as above
 2018-03-05 [854dd8cff] Add parenthesized options syntax for ANALYZE.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add parenthesized options syntax to <command>ANALYZE</command>
         (Nathan Bossart)
        </para>
+____________________________________________________________________________-->
+       <para>
+        把括号括起来的选项语法增加到<command>ANALYZE</command> (Nathan Bossart)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This is similar to the syntax supported by
         <command>VACUUM</command>.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        这类似于<command>VACUUM</command>支持的语法。
        </para>
       </listitem>
 
@@ -3743,14 +5508,24 @@ same commits as above
 2017-10-16 [be0ebb65f] Allow the built-in ordered-set aggregates to share trans
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add <command>CREATE AGGREGATE</command> option to specify the
         behavior of the aggregate's finalization function (Tom Lane)
        </para>
+____________________________________________________________________________-->
+       <para>
+        增加<command>CREATE AGGREGATE</command>选项以指定聚集的终结函数的行为 (Tom Lane)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This is helpful for allowing user-defined aggregate functions to be
         optimized and to work as window functions.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        这有助于允许用户定义聚集函数的优化、用作窗口函数。
        </para>
 
       </listitem>
@@ -3760,7 +5535,10 @@ same commits as above
    </sect3>
 
    <sect3>
+<!--==========================orignal english content==========================
     <title>Data Types</title>
+____________________________________________________________________________-->
+    <title>数据类型</title>
 
     <itemizedlist>
 
@@ -3769,13 +5547,23 @@ same commits as above
 2017-09-30 [c12d570fa] Support arrays over domains.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow the creation of arrays of domains (Tom Lane)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许创建域数组 (Tom Lane)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This also allows <function>array_agg()</function> to be used
         on domains.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        这也允许<function>array_agg()</function>用在域上。
        </para>
       </listitem>
 
@@ -3787,14 +5575,24 @@ same commits as above
 2017-11-16 [687f096ea] Make PL/Python handle domain-type conversions correctly.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Support domains over composite types (Tom Lane)
        </para>
+____________________________________________________________________________-->
+       <para>
+        支持符合类型上的域 (Tom Lane)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Also allow PL/Perl, PL/Python, and PL/Tcl to handle
         composite-domain function arguments and results.  Also improve
         PL/Python domain handling.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        也允许PL/Perl, PL/Python和PL/Tcl处理复合域函数参数和结果。亦改进了PL/Python的域处理。
        </para>
       </listitem>
 
@@ -3803,9 +5601,14 @@ same commits as above
 2018-03-29 [c0cbe00fe] Add casts from jsonb
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add casts from <type>JSONB</type> scalars to numeric and boolean data
         types (Anastasia Lubennikova)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        增加从<type>JSONB</type>标量到数字和布尔数据类型的类型转换 (Anastasia Lubennikova)
        </para>
 
       </listitem>
@@ -3815,7 +5618,10 @@ same commits as above
    </sect3>
 
    <sect3>
+<!--==========================orignal english content==========================
     <title>Functions</title>
+____________________________________________________________________________-->
+    <title>函数</title>
 
     <itemizedlist>
 
@@ -3825,11 +5631,17 @@ same commits as above
 2018-02-24 [8b29e88cd] Add window RANGE support for float4, float8, numeric.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add all <link linkend="sql-window">window function</link> framing
         options specified by SQL:2011 (Oliver Ford, Tom Lane)
        </para>
+____________________________________________________________________________-->
+       <para>
+        增加SQL:2011指定的所有<link linkend="sql-window">窗口函数</link>帧选项 (Oliver Ford, Tom Lane)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Specifically, allow <literal>RANGE</literal> mode to use
         <literal>PRECEDING</literal> and <literal>FOLLOWING</literal> to
@@ -3837,6 +5649,10 @@ same commits as above
         specified offset.  Add <literal>GROUPS</literal> mode to include plus
         or minus the number of peer groups.  Frame exclusion syntax was also
         added.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        特别地，允许<literal>RANGE</literal>模式使用<literal>PRECEDING</literal>和<literal>FOLLOWING</literal>选择那些在指定正负偏移内有分组的行。增加<literal>GROUPS</literal>模式以包含加减该数量的对等组。帧排除语法也加进来了。
        </para>
 
       </listitem>
@@ -3846,16 +5662,26 @@ same commits as above
 2018-02-22 [10cfce34c] Add user-callable SHA-2 functions
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add <acronym>SHA-2</acronym> family of hash functions (Peter
         Eisentraut)
        </para>
+____________________________________________________________________________-->
+       <para>
+        增加<acronym>SHA-2</acronym>哈希函数家族 (Peter Eisentraut)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Specifically, <link
         linkend="functions-binarystring-other"><function>sha224()</function></link>,
         <function>sha256()</function>, <function>sha384()</function>,
         <function>sha512()</function> were added.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        特别地，增加<link linkend="functions-binarystring-other"><function>sha224()</function></link>,<function>sha256()</function>, <function>sha384()</function>,<function>sha512()</function>。
        </para>
       </listitem>
 
@@ -3864,9 +5690,14 @@ same commits as above
 2017-08-31 [81c5e46c4] Introduce 64-bit hash functions with a 64-bit seed.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add support for 64-bit non-cryptographic hash functions (Robert
         Haas, Amul Sul)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        增加对64位非加密哈希函数的支持 (Robert Haas, Amul Sul)
        </para>
       </listitem>
 
@@ -3875,17 +5706,27 @@ same commits as above
 2018-01-09 [11b623dd0] Implement TZH and TZM timestamp format patterns
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow <function>to_char()</function> and
         <function>to_timestamp()</function> to specify the time zone's
         offset from <acronym>UTC</acronym> in hours and minutes
         (Nikita Glukhov, Andrew Dunstan)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许<function>to_char()</function>和<function>to_timestamp()</function>指定自<acronym>UTC</acronym>的时区偏移的小时和分钟 (Nikita Glukhov, Andrew Dunstan)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This is done with format specifications <link
         linkend="functions-formatting-datetime-table"><literal>TZH</literal></link>
         and <literal>TZM</literal>.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        这以<link linkend="functions-formatting-datetime-table"><literal>TZH</literal></link>和<literal>TZM</literal>格式规范来实施。
        </para>
       </listitem>
 
@@ -3894,11 +5735,16 @@ same commits as above
 2018-04-05 [1664ae197] Add websearch_to_tsquery
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add text search function <link
         linkend="textsearch-functions-table"><function>websearch_to_tsquery()</function></link>
         that supports a query syntax similar to that used by web search
         engines (Victor Drobny, Dmitry Ivanov)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        增加搜索函数<link linkend="textsearch-functions-table"><function>websearch_to_tsquery()</function></link>，支持一种类似于Web搜索引擎使用的查询语法 (Victor Drobny, Dmitry Ivanov)
        </para>
       </listitem>
 
@@ -3907,11 +5753,16 @@ same commits as above
 2018-04-07 [1c1791e00] Add json(b)_to_tsvector function
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add functions <link
         linkend="textsearch-functions-table"><function>json(b)_to_tsvector()</function></link>
         to create a text search query for matching
         <type>JSON</type>/<type>JSONB</type> values (Dmitry Dolgov)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        增加<link linkend="textsearch-functions-table"><function>json(b)_to_tsvector()</function></link>函数以创建用于匹配<type>JSON</type>/<type>JSONB</type>值的文本搜索查询 (Dmitry Dolgov)
        </para>
 
       </listitem>
@@ -3921,7 +5772,10 @@ same commits as above
    </sect3>
 
    <sect3>
+<!--==========================orignal english content==========================
     <title>Server-Side Languages</title>
+____________________________________________________________________________-->
+    <title>服务器端语言</title>
 
     <itemizedlist>
 
@@ -3935,30 +5789,50 @@ same commits as above
 2018-08-22 [fd4417e8a] Change PROCEDURE to FUNCTION in CREATE OPERATOR syntax
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add SQL-level procedures, which can start and commit their own
         transactions (Peter Eisentraut)
        </para>
+____________________________________________________________________________-->
+       <para>
+        增加SQL级过程，在过程中能够开始和提交其自身的事务 (Peter Eisentraut)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         They are created with the new <link
         linkend="sql-createprocedure"><command>CREATE
         PROCEDURE</command></link> command and invoked via <link
         linkend="sql-call"><command>CALL</command></link>.
        </para>
+____________________________________________________________________________-->
+       <para>
+        用新命令<link linkend="sql-createprocedure"><command>CREATE PROCEDURE</command></link>创建过程，用<link linkend="sql-call"><command>CALL</command></link>来调用。
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         The new <command>ALTER</command>/<command>DROP ROUTINE</command>
         commands allow altering/dropping of all routine-like objects,
         including procedures, functions, and aggregates.
        </para>
+____________________________________________________________________________-->
+       <para>
+        新命令<command>ALTER</command>/<command>DROP ROUTINE</command>可以改变/删除所有类似程序的对象，包括过程、函数和聚集。
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Also, writing <literal>FUNCTION</literal> is now preferred
         over writing <literal>PROCEDURE</literal> in <command>CREATE
         OPERATOR</command> and <command>CREATE TRIGGER</command>, because the
         referenced object must be a function not a procedure.  However, the
         old syntax is still accepted for compatibility.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        而且在<command>CREATE OPERATOR</command>和<command>CREATE TRIGGER</command>时，现在写<literal>FUNCTION</literal>比写<literal>PROCEDURE</literal>好，因为引用的对象必须是函数而非过程。但是，为了兼容性，仍然接受过去的语法。
        </para>
       </listitem>
 
@@ -3970,16 +5844,26 @@ same commits as above
 2018-04-05 [b981275b6] PL/pgSQL: Add support for SET TRANSACTION
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add transaction control to PL/pgSQL, PL/Perl, PL/Python, PL/Tcl,
         and <acronym>SPI</acronym> server-side languages (Peter Eisentraut)
        </para>
+____________________________________________________________________________-->
+       <para>
+        将事务控制增加到PL/pgSQL, PL/Perl, PL/Python, PL/Tcl和<acronym>SPI</acronym>服务器端语言中 (Peter Eisentraut)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Transaction control is only available within top-transaction-level
         procedures and nested <command>DO</command> and
         <command>CALL</command> blocks that only contain other
         <command>DO</command> and <command>CALL</command> blocks.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        事务控制仅在顶部事务层过程和仅包含其它<command>DO</command>和<command>CALL</command>块的嵌套<command>DO</command>和<command>CALL</command>块中可用。
        </para>
       </listitem>
 
@@ -3988,9 +5872,14 @@ same commits as above
 2018-02-13 [f9263006d] Support CONSTANT/NOT NULL/initial value for plpgsql comp
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add the ability to define PL/pgSQL composite-type variables as not
         null, constant, or with initial values (Tom Lane)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        增加将PL/pgSQL复合类型变量定义为非空、常数或带初始值的功能 (Tom Lane)
        </para>
       </listitem>
 
@@ -3999,14 +5888,24 @@ same commits as above
 2018-02-13 [4b93f5799] Make plpgsql use its DTYPE_REC code paths for composite-
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow PL/pgSQL to handle changes to composite types (e.g. record,
         row) that happen between the first and later function executions
         in the same session (Tom Lane)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许PL/pgSQL处理同一会话中发生在第一次和后来函数执行之间对复合类型的修改 (Tom Lane)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Previously, such circumstances generated errors.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        以前这些情况产生错误。
        </para>
       </listitem>
 
@@ -4015,9 +5914,15 @@ same commits as above
 2018-03-28 [3f44e3db7] Transforms for jsonb to PL/Python
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add extension <filename>jsonb_plpython</filename> to
         transform <type>JSONB</type> to/from PL/Python types (Anthony
+        Bykov)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        增加<filename>jsonb_plpython</filename>扩展以转换<type>JSONB</type>到/自PL/Python类型 (Anthony
         Bykov)
        </para>
       </listitem>
@@ -4027,9 +5932,14 @@ same commits as above
 2018-04-03 [341e16618] Transforms for jsonb to PL/Perl
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add extension <filename>jsonb_plperl</filename> to transform
         <type>JSONB</type> to/from PL/Perl types (Anthony Bykov)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        增加<filename>jsonb_plperl</filename>扩展以转换<type>JSONB</type>到/自PL/Perl类型 (Anthony Bykov)
        </para>
 
       </listitem>
@@ -4039,7 +5949,10 @@ same commits as above
    </sect3>
 
    <sect3>
+<!--==========================orignal english content==========================
     <title>Client Interfaces</title>
+____________________________________________________________________________-->
+    <title>客户端接口</title>
 
     <itemizedlist>
 
@@ -4048,13 +5961,23 @@ same commits as above
 2018-03-17 [e3bdb2d92] Set libpq sslcompression to off by default
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Change libpq to disable compression by default (Peter Eisentraut)
        </para>
+____________________________________________________________________________-->
+       <para>
+        修改libpq，以禁用默认的压缩 (Peter Eisentraut)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Compression is already disabled in modern OpenSSL versions, so that
         the libpq setting had no effect with such libraries.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        现代的OpenSSL版本中，压缩已被禁用，故与这些库一起的libpq设置无效。
        </para>
       </listitem>
 
@@ -4063,16 +5986,26 @@ same commits as above
 2017-08-25 [d22e9d530] Implement <literal>DO CONTINUE</literal> action for <literal>ECPG WHENEVER</literal> statement
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add <literal>DO CONTINUE</literal> option
         to <application>ecpg</application>'s <literal>WHENEVER</literal>
         statement (Vinayak Pokale)
        </para>
+____________________________________________________________________________-->
+       <para>
+        将<literal>DO CONTINUE</literal>选项加到<application>ecpg</application>的<literal>WHENEVER</literal>语句中 (Vinayak Pokale)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This generates a C <command>continue</command> statement, causing a
         return to the top of the contained loop when the specified condition
         occurs.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        这会产生C的<command>continue</command>语句，特定条件发生时将导致返回含有它的循环的顶部。
        </para>
       </listitem>
 
@@ -4081,13 +6014,23 @@ same commits as above
 2018-03-14 [3b7ab4380] Add Oracle like handling of char arrays.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add an <application>ecpg</application> mode to enable Oracle
         Pro*C-style handling of char arrays.
        </para>
+____________________________________________________________________________-->
+       <para>
+        增加<application>ecpg</application>模式以启用Oracle Pro*C风格的字符数组处理方式。
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This mode is enabled with <option>-C</option>.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        该模式用<option>-C</option>来启用。
        </para>
 
       </listitem>
@@ -4097,9 +6040,15 @@ same commits as above
    </sect3>
 
    <sect3>
+<!--==========================orignal english content==========================
     <title>Client Applications</title>
+____________________________________________________________________________-->
+    <title>客户端应用程序</title>
 
     <sect4>
+<!--==========================orignal english content==========================
+     <title><xref linkend="app-psql"/></title>
+____________________________________________________________________________-->
      <title><xref linkend="app-psql"/></title>
 
      <itemizedlist>
@@ -4109,10 +6058,15 @@ same commits as above
 2017-09-05 [49ca462eb] Add \gdesc psql command.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add <application>psql</application> command <literal>\gdesc</literal>
         to display the names and types of the columns in a query result
         (Pavel Stehule)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        增加<application>psql</application>命令<literal>\gdesc</literal>以显示查询结果中的列的名字和类型 (Pavel Stehule)
        </para>
       </listitem>
 
@@ -4121,16 +6075,26 @@ same commits as above
 2017-09-12 [69835bc89] Add psql variables to track success/failure of SQL queri
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add <application>psql</application> variables to report query
         activity and errors (Fabien Coelho)
        </para>
+____________________________________________________________________________-->
+       <para>
+        增加<application>psql</application>变量以报告查询活动或错误 (Fabien Coelho)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Specifically, the new variables are <literal>ERROR</literal>,
         <literal>SQLSTATE</literal>, <literal>ROW_COUNT</literal>,
         <literal>LAST_ERROR_MESSAGE</literal>, and
         <literal>LAST_ERROR_SQLSTATE</literal>.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        特别地，这些新变量是<literal>ERROR</literal>,<literal>SQLSTATE</literal>, <literal>ROW_COUNT</literal>,<literal>LAST_ERROR_MESSAGE</literal>和<literal>LAST_ERROR_SQLSTATE</literal>。
        </para>
       </listitem>
 
@@ -4139,15 +6103,25 @@ same commits as above
 2017-09-21 [d57c7a7c5] Provide a test for variable existence in psql
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow <application>psql</application> to test for the existence
         of a variable (Fabien Coelho)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许<application>psql</application>测试一个变量是否存在 (Fabien Coelho)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Specifically, the syntax <literal>:{?variable_name}</literal> allows
         a variable's existence to be tested in an <literal>\if</literal>
         statement.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        特别地，语法<literal>:{?variable_name}</literal>允许在<literal>\if</literal>语句中测试变量是否存在。
        </para>
       </listitem>
 
@@ -4156,16 +6130,26 @@ same commits as above
 2017-09-05 [5e8304fdc] In psql, use PSQL_PAGER in preference to PAGER, if it's
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow environment variable <envar>PSQL_PAGER</envar> to control
         <application>psql</application>'s pager (Pavel Stehule)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许环境变量<envar>PSQL_PAGER</envar>控制<application>psql</application>的分页 (Pavel Stehule)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This allows <application>psql</application>'s default pager to
         be specified as a separate environment variable from the pager
         for other applications.  <envar>PAGER</envar> is still honored
         if <envar>PSQL_PAGER</envar> is not set.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        该项功能允许<application>psql</application>的缺省分页器可指定为单独环境变量，与其它应用程序分页器分开。如果<envar>PSQL_PAGER</envar>未设置，<envar>PAGER</envar>仍然起作用。
        </para>
       </listitem>
 
@@ -4174,15 +6158,25 @@ same commits as above
 2017-11-23 [05b6ec39d] Show partition info from psql \d+
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Make psql's <literal>\d+</literal> command always show the table's
         partitioning information (Amit Langote, Ashutosh Bapat)
        </para>
+____________________________________________________________________________-->
+       <para>
+        使psql的<literal>\d+</literal>命令总显示表分区信息 (Amit Langote, Ashutosh Bapat)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Previously, partition information would not be displayed for a
         partitioned table if it had no partitions.  Also indicate which
         partitions are themselves partitioned.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        以前如果无分区，分区表不会显示分区信息。现在也要显示哪些分区是如何划分的。
        </para>
       </listitem>
 
@@ -4191,16 +6185,26 @@ same commits as above
 2018-01-29 [15be27460] Avoid misleading psql password prompt when username is m
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Ensure that <application>psql</application> reports the proper user
         name when prompting for a password (Tom Lane)
        </para>
+____________________________________________________________________________-->
+       <para>
+        确保<application>psql</application>提示输入密码时报告确切的用户名 (Tom Lane)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Previously, combinations of <option>-U</option> and a user name
         embedded in a <acronym>URI</acronym> caused incorrect reporting.
         Also suppress the user name before the password prompt when
-        <option>--password</option> is specified.
+        <option>-&minus;password</option> is specified.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        以前嵌入在<acronym>URI</acronym>中的<option>-U</option>和用户名的组合会导致错误的报告。当指定<option>--password</option>时，也会在密码提示之前禁止（显示）用户名。
        </para>
       </listitem>
 
@@ -4209,16 +6213,26 @@ same commits as above
 2018-02-01 [df9f599bc] psql:  Add quit/help behavior/hint, for other tool porta
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow <command>quit</command> and <command>exit</command> to
         exit <application>psql</application> when given with no prior input
         (Bruce Momjian)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许没有先前输入时，使用<command>quit</command>和<command>exit</command>退出<application>psql</application> (Bruce Momjian)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Also print hints about how to exit when <command>quit</command> and
         <command>exit</command> are used alone on a line while the input
         buffer is not empty.  Add a similar hint for <command>help</command>.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        此外输入缓冲区非空时，若在一行中单独使用<command>quit</command>和<command>exit</command>，则打印如何退出的提示。对于<command>help</command>也添加了类似的提示。
        </para>
       </listitem>
 
@@ -4227,15 +6241,25 @@ same commits as above
 2018-02-12 [91389228a] psql:  give ^D hint for \q in place where \q is ignored
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Make <application>psql</application> hint at using control-D
         when <command>\q</command> is entered alone on a line but ignored
         (Bruce Momjian)
        </para>
+____________________________________________________________________________-->
+       <para>
+        在一行中单独输入了<command>\q</command>但被忽略时，让<application>psql</application>提示使用CTRL+D (Bruce Momjian)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         For example, <command>\q</command> does not exit when supplied
         in character strings.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        例如，当<command>\q</command>是在字符串中给出时，该命令并不退出。
        </para>
       </listitem>
 
@@ -4244,9 +6268,14 @@ same commits as above
 2018-03-03 [2b8c94e1b] Improve tab-completion for ALTER INDEX RESET/SET.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Improve tab completion for <command>ALTER INDEX
         RESET</command>/<command>SET</command> (Masahiko Sawada)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        改进<command>ALTER INDEX RESET</command>/<command>SET</command>的制表符 (Masahiko Sawada)
        </para>
       </listitem>
 
@@ -4255,14 +6284,24 @@ same commits as above
 2018-03-05 [722408bcd] Add infrastructure to support server-version-dependent t
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add infrastructure to allow <application>psql</application>
         to adapt its tab completion queries based on the server version
         (Tom Lane)
        </para>
+____________________________________________________________________________-->
+       <para>
+        增加允许<application>psql</application>基于服务器版本适配其制表符自动补全查询的基础架构 (Tom Lane)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Previously, tab completion queries could fail against older servers.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        以前对老版本服务器的制表符自动补全查询会失败。
        </para>
 
       </listitem>
@@ -4272,6 +6311,9 @@ same commits as above
     </sect4>
 
     <sect4>
+<!--==========================orignal english content==========================
+     <title><link linkend="pgbench"><application>pgbench</application></link></title>
+____________________________________________________________________________-->
      <title><link linkend="pgbench"><application>pgbench</application></link></title>
 
      <itemizedlist>
@@ -4281,9 +6323,14 @@ same commits as above
 2018-01-09 [bc7fa0c15] Improve scripting language in pgbench
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add <application>pgbench</application> expression support for
         NULLs, booleans, and some functions and operators (Fabien Coelho)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        在<application>pgbench</application>中增加对NULL、布尔数和一些函数与操作符的表达式支持 (Fabien Coelho)
        </para>
       </listitem>
 
@@ -4292,9 +6339,14 @@ same commits as above
 2018-03-22 [f67b113ac] Add \if support to pgbench
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add <literal>\if</literal> conditional support to
         <application>pgbench</application> (Fabien Coelho)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        在<application>pgbench</application>中增加<literal>\if</literal>条件支持 (Fabien Coelho)
        </para>
       </listitem>
 
@@ -4303,9 +6355,14 @@ same commits as above
 2017-09-04 [9d36a3866] Adjust pgbench to allow non-ASCII characters in variable
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow the use of non-<acronym>ASCII</acronym> characters in
         <application>pgbench</application> variable names (Fabien Coelho)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        允许在<application>pgbench</application>变量名中使用非<acronym>ASCII</acronym>字符 (Fabien Coelho)
        </para>
       </listitem>
 
@@ -4314,10 +6371,15 @@ same commits as above
 2017-11-13 [591c504fa] Allow running just selected steps of pgbench's initializ
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add <application>pgbench</application> option
-        <option>--init-steps</option> to control the initialization steps
+        <option>-&minus;init-steps</option> to control the initialization steps
         performed (Masahiko Sawada)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        增加<application>pgbench</application>选项<option>--init-steps</option>以控制初始化步骤的执行 (Masahiko Sawada)
        </para>
       </listitem>
 
@@ -4326,9 +6388,14 @@ same commits as above
 2017-12-14 [1fcd0adeb] Add approximated Zipfian-distributed random generator to
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add an approximately Zipfian-distributed random generator to
         <application>pgbench</application> (Alik Khilazhev)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        将一种近似于Zipfian分布的随机数发生器添加到<application>pgbench</application> (Alik Khilazhev)
        </para>
       </listitem>
 
@@ -4337,9 +6404,14 @@ same commits as above
 2018-03-26 [64f85894a] Set random seed for pgbench.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow the random seed to be set in
         <application>pgbench</application> (Fabien Coelho)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        允许在<application>pgbench</application>中设置随机数种子 (Fabien Coelho)
        </para>
       </listitem>
 
@@ -4348,10 +6420,15 @@ same commits as above
 2017-12-27 [7a727c180] Add pow(), aka power(), function to pgbench.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow <application>pgbench</application> to do exponentiation
         with <function>pow()</function> and <function>power()</function>
         (Ra&uacute;l Mar&iacute;n Rodr&iacute;guez)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        允许<application>pgbench</application>用<function>pow()</function>和<function>power()</function>来做幂运算 (Ra&uacute;l Mar&iacute;n Rodr&iacute;guez)
        </para>
       </listitem>
 
@@ -4360,9 +6437,14 @@ same commits as above
 2018-03-21 [e51a04840] Add general purpose hasing functions to pgbench.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add hashing functions to <application>pgbench</application>
         (Ildar Musin)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        将哈希函数添加到<application>pgbench</application> (Ildar Musin)
        </para>
       </listitem>
 
@@ -4372,10 +6454,15 @@ same commits as above
 2017-11-21 [16827d442] pgbench: fix stats reporting when some transactions are
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Make <application>pgbench</application> statistics more
-        accurate when using <option>--latency-limit</option> and
-        <option>--rate</option> (Fabien Coelho)
+        accurate when using <option>-&minus;latency-limit</option> and
+        <option>-&minus;rate</option> (Fabien Coelho)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        当使用<option>--latency-limit</option>和<option>--rate</option>时，使<application>pgbench</application>统计更准确 (Fabien Coelho)
        </para>
 
       </listitem>
@@ -4387,7 +6474,10 @@ same commits as above
    </sect3>
 
    <sect3>
+<!--==========================orignal english content==========================
     <title>Server Applications</title>
+____________________________________________________________________________-->
+    <title>服务器应用程序</title>
 
     <itemizedlist>
 
@@ -4396,17 +6486,27 @@ same commits as above
 2017-09-27 [3709ca1cf] pg_basebackup: Add option to create replication slot
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add an option to <link
         linkend="app-pgbasebackup"><application>pg_basebackup</application></link>
         that creates a named replication slot (Michael Banck)
        </para>
-
+____________________________________________________________________________-->
        <para>
-        The option <option>--create-slot</option> creates
-        the named replication slot (<option>--slot</option>)
+        在<link linkend="app-pgbasebackup"><application>pg_basebackup</application></link>增加一创建命名复制槽的选项 (Michael Banck)
+       </para>
+
+<!--==========================orignal english content==========================
+       <para>
+        The option <option>-&minus;create-slot</option> creates
+        the named replication slot (<option>-&minus;slot</option>)
         when the <acronym>WAL</acronym> streaming method
-        (<option>--wal-method=stream</option>) is used.
+        (<option>-&minus;wal-method=stream</option>) is used.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        使用<acronym>WAL</acronym>流式方法时，选项<option>--create-slot</option>创建命名复制槽(<option>--slot</option>)。
        </para>
       </listitem>
 
@@ -4415,19 +6515,30 @@ same commits as above
 2018-04-07 [c37b3d08c] Allow group access on PGDATA
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow <link
         linkend="app-initdb"><application>initdb</application></link>
         to set group read access to the data directory (David Steele)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许<link linkend="app-initdb"><application>initdb</application></link>设置对数据目录的组读取访问 (David Steele)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This is accomplished with the new initdb option
-        <option>--allow-group-access</option>.  Administrators
+        <option>-&minus;allow-group-access</option>.  Administrators
         can also set group permissions on the empty data
         directory before running initdb.  Server variable <link
         linkend="guc-data-directory"><varname>data_directory_mode</varname></link>
         allows reading of data directory group permissions.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        该功能用新的initdb选项<option>--allow-group-access</option>来实现。在运行initdb之前，管理员也可以对空数据目录设置组权限。服务器变量<link
+        linkend="guc-data-directory"><varname>data_directory_mode</varname></link>允许读取数据目录组权限。
        </para>
       </listitem>
 
@@ -4437,10 +6548,15 @@ same commits as above
 2018-04-09 [a228cc13a] Revert "Allow on-line enabling and disabling of data che
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add <link
         linkend="pgverifychecksums"><application>pg_verify_checksums</application></link>
         tool to verify database checksums while offline (Magnus Hagander)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        增加<link linkend="pgverifychecksums"><application>pg_verify_checksums</application></link>工具以验证离线时数据库校验和 (Magnus Hagander)
        </para>
       </listitem>
 
@@ -4449,11 +6565,16 @@ same commits as above
 2018-03-25 [bf4a8676c] pg_resetwal: Allow users to change the WAL segment size
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow <link
         linkend="app-pgresetwal"><application>pg_resetwal</application></link>
         to change the <acronym>WAL</acronym> segment size via
-        <option>--wal-segsize</option> (Nathan Bossart)
+        <option>-&minus;wal-segsize</option> (Nathan Bossart)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        允许<link linkend="app-pgresetwal"><application>pg_resetwal</application></link>通过<option>--wal-segsize</option>修改<acronym>WAL</acronym>大小 (Nathan Bossart)
        </para>
       </listitem>
 
@@ -4462,10 +6583,15 @@ same commits as above
 2018-03-24 [e22b27f0c] Add long options to pg_resetwal and pg_controldata
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add long options to <application>pg_resetwal</application>
         and <application>pg_controldata</application> (Nathan Bossart,
         Peter Eisentraut)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        在<application>pg_resetwal</application>和<application>pg_controldata</application>中增加长选项 (Nathan Bossart, Peter Eisentraut)
        </para>
       </listitem>
 
@@ -4474,11 +6600,16 @@ same commits as above
 2017-10-29 [5f3971291] pg_receivewal: Add - -no-sync option.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add <link
         linkend="app-pgreceivewal"><application>pg_receivewal</application></link>
-        option <option>--no-sync</option> to prevent synchronous
+        option <option>-&minus;no-sync</option> to prevent synchronous
         <acronym>WAL</acronym> writes, for testing (Michael Paquier)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        为了测试，将<option>--no-sync</option>选项添加到<link linkend="app-pgreceivewal"><application>pg_receivewal</application></link>以防止同步<acronym>WAL</acronym>写 (Michael Paquier)
        </para>
       </listitem>
 
@@ -4487,10 +6618,15 @@ same commits as above
 2017-09-11 [6d9fa5264] pg_receivewal: Add - -endpos option
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add <application>pg_receivewal</application> option
-        <option>--endpos</option> to specify when <acronym>WAL</acronym>
+        <option>-&minus;endpos</option> to specify when <acronym>WAL</acronym>
         receiving should stop (Michael Paquier)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        将<option>--endpos</option>选项添加到<application>pg_receivewal</application>以指定<acronym>WAL</acronym>接收何时停止 (Michael Paquier)
        </para>
       </listitem>
 
@@ -4499,15 +6635,25 @@ same commits as above
 2017-10-01 [2e83db3ad] Allow pg_ctl kill to send SIGKILL.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow <link
         linkend="app-pg-ctl"><application>pg_ctl</application></link>
         to send the <literal>SIGKILL</literal> signal to processes
         (Andres Freund)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许<link linkend="app-pg-ctl"><application>pg_ctl</application></link>向进程发送<literal>SIGKILL</literal>信号 (Andres Freund)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This was previously unsupported due to concerns over possible misuse.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        以前该功能是不支持的，原因是担心可能被误用。
        </para>
       </listitem>
 
@@ -4516,10 +6662,15 @@ same commits as above
 2018-03-29 [266b6acb3] Make pg_rewind skip files and directories that are remov
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Reduce the number of files copied by <link
         linkend="app-pgrewind"><application>pg_rewind</application></link>
         (Michael Paquier)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        减少<link linkend="app-pgrewind"><application>pg_rewind</application></link>复制的文件数量 (Michael Paquier)
        </para>
       </listitem>
 
@@ -4528,9 +6679,14 @@ same commits as above
 2018-04-09 [5d5aeddab] Make sure pg_rewind can't run as root
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Prevent <application>pg_rewind</application> from running as
         <literal>root</literal> (Michael Paquier)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        防止<application>pg_rewind</application>从<literal>root</literal>用户运行 (Michael Paquier)
        </para>
 
       </listitem>
@@ -4538,6 +6694,11 @@ same commits as above
      </itemizedlist>
 
     <sect4>
+<!--==========================orignal english content==========================
+     <title><link linkend="app-pgdump"><application>pg_dump</application></link>,
+     <link linkend="app-pg-dumpall"><application>pg_dumpall</application></link>,
+     <link linkend="app-pgrestore"><application>pg_restore</application></link></title>
+____________________________________________________________________________-->
      <title><link linkend="app-pgdump"><application>pg_dump</application></link>,
      <link linkend="app-pg-dumpall"><application>pg_dumpall</application></link>,
      <link linkend="app-pgrestore"><application>pg_restore</application></link></title>
@@ -4549,14 +6710,24 @@ same commits as above
 2017-09-01 [84be67181] pg_dumpall: Add a -E flag to set the encoding, like pg_d
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add <application>pg_dumpall</application> option
-        <option>--encoding</option> to control output encoding
+        <option>-&minus;encoding</option> to control output encoding
         (Michael Paquier)
        </para>
+____________________________________________________________________________-->
+       <para>
+        增加<application>pg_dumpall</application>选项<option>--encoding</option>用来控制输出的编码 (Michael Paquier)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         <application>pg_dump</application> already had this option.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        <application>pg_dump</application>已有此选项。
        </para>
       </listitem>
 
@@ -4565,17 +6736,27 @@ same commits as above
 2017-08-14 [23d7680d0] pg_dump: Add a - -load-via-partition-root option.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add <application>pg_dump</application> option
-        <option>--load-via-partition-root</option> to force loading of
+        <option>-&minus;load-via-partition-root</option> to force loading of
         data into the partition's root table, rather than the original
         partition (Rushabh Lathia)
        </para>
+____________________________________________________________________________-->
+       <para>
+        增加<application>pg_dump</application>选项<option>--load-via-partition-root</option>，强制将数据加载到分区的根表中，而不是原来的分区 (Rushabh Lathia)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This is useful if the system to be loaded to has different collation
         definitions or endianness, possibly requiring rows to be stored in
         different partitions than previously.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        如果系统要加载到不同的排序规则定义或字节序的库，相比以前而言可能需要将行存储在不同的分区。这种情况下就很有用。
        </para>
       </listitem>
 
@@ -4584,16 +6765,26 @@ same commits as above
 2018-01-25 [1368e92e1] Support - -no-comments in pg_dump, pg_dumpall, pg_restore
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add an option to suppress dumping and restoring database object
         comments (Robins Tharakan)
        </para>
+____________________________________________________________________________-->
+       <para>
+        增加禁止转储和恢复数据库对象注释的选项 (Robins Tharakan)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         The new <application>pg_dump</application>,
         <application>pg_dumpall</application>, and
         <application>pg_restore</application> option is
-        <option>--no-comments</option>.
+        <option>-&minus;no-comments</option>.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        新的<application>pg_dump</application><application>pg_dumpall</application>和<application>pg_restore</application>选项是<option>--no-comments</option>。
        </para>
 
       </listitem>
@@ -4605,7 +6796,10 @@ same commits as above
    </sect3>
 
    <sect3>
+<!--==========================orignal english content==========================
     <title>Source Code</title>
+____________________________________________________________________________-->
+    <title>源代码</title>
 
     <itemizedlist>
 
@@ -4616,11 +6810,17 @@ same commits as above
 2018-09-07 [094ffd684] Refactor installation of extension headers.
 2018-09-16 [f1ca5a654] Fix out-of-tree build for transform modules.
 -->
+<!--==========================orignal english content==========================
        <para>
         Add <application>PGXS</application> support for installing include
         files (Andrew Gierth)
        </para>
+____________________________________________________________________________-->
+       <para>
+        增加<application>PGXS</application>支持以安装头文件 (Andrew Gierth)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This supports creating extension modules that depend on other
         modules.  Formerly there was no easy way for the dependent module to
@@ -4630,6 +6830,10 @@ same commits as above
         PL/Python now install their include files, to support creation of
         transform modules for those languages.
        </para>
+____________________________________________________________________________-->
+       <para>
+        这样可支持创建依赖其他模块的扩展模块。以前没有容易的方法让依赖模块找到所引用的模块的头文件。现有的几个定义数据类型的<filename>contrib</filename>模块已经调整，安装了相关文件。PL/Perl和PL/Python现在也安装了它们的头文件，以支持语言转换模块的创建。
+       </para>
       </listitem>
 
       <listitem>
@@ -4637,10 +6841,15 @@ same commits as above
 2018-04-05 [1fd869066] Install errcodes.txt for use by extensions.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Install <filename>errcodes.txt</filename> to allow extensions to access
         the list of error codes known to <productname>PostgreSQL</productname>
         (Thomas Munro)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        安装<filename>errcodes.txt</filename>，以允许扩展访问<productname>PostgreSQL</productname>所知的错误代码列表 (Thomas Munro)
        </para>
       </listitem>
 
@@ -4652,14 +6861,24 @@ same commits as above
 2017-11-23 [3c49c6fac] Convert documentation to DocBook XML
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Convert documentation to DocBook <acronym>XML</acronym> (Peter
         Eisentraut, Alexander Lakhin, J&uuml;rgen Purtz)
        </para>
+____________________________________________________________________________-->
+       <para>
+        将文档转成了DocBook <acronym>XML</acronym>格式 (Peter Eisentraut, Alexander Lakhin, J&uuml;rgen Purtz)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         The file names still use an <filename>sgml</filename> extension
         for compatibility with back branches.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        为了与以前分支兼容，文件名仍使用<filename>sgml</filename>扩展名。
        </para>
       </listitem>
 
@@ -4670,14 +6889,24 @@ same commits as above
 2018-05-02 [6fe25c135] Change SIZEOF_BOOL to 1 for Windows.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Use <filename>stdbool.h</filename> to define type <type>bool</type>
         on platforms where it's suitable, which is most (Peter Eisentraut)
        </para>
+____________________________________________________________________________-->
+       <para>
+        在合适的平台上（大多数是这样），使用<filename>stdbool.h</filename>定义<type>bool</type>类型 (Peter Eisentraut)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This eliminates a coding hazard for extension modules that need
         to include <filename>stdbool.h</filename>.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        这样就消除了需包含<filename>stdbool.h</filename>的扩展模块的编码危险。
        </para>
       </listitem>
 
@@ -4693,14 +6922,24 @@ same commits as above
 2018-05-05 [d160882a1] Fix bootstrap parser so that its keywords are unreserved
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Overhaul the way that initial system catalog contents are defined
         (John Naylor)
        </para>
+____________________________________________________________________________-->
+       <para>
+        彻底修改初始系统目录内容定义的方法 (John Naylor)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         The initial data is now represented in Perl data structures, making
         it much easier to manipulate mechanically.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        初始数据现在用Perl数据结构表示，使之更易进行机械式处理。
        </para>
       </listitem>
 
@@ -4709,15 +6948,25 @@ same commits as above
 2018-03-21 [846b5a525] Prevent extensions from creating custom GUCs that are GU
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Prevent extensions from creating custom server parameters that
         take a quoted list of values (Tom Lane)
        </para>
+____________________________________________________________________________-->
+       <para>
+        防止扩展创建带引号的值列表自定义服务器参数 (Tom Lane)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This cannot be supported at present because knowledge of the
         parameter's property would be required even before the extension is
         loaded.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        该功能目前不支持，因为即使在扩展加载之前也需要参数属性的知识。
        </para>
       </listitem>
 
@@ -4728,18 +6977,28 @@ same commits as above
 2018-01-04 [d3fb72ea6] Implement channel binding tls-server-end-point for SCRAM
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add ability to use channel binding when using <link
         linkend="auth-password"><acronym>SCRAM</acronym></link>
         authentication (Michael Paquier)
        </para>
+____________________________________________________________________________-->
+       <para>
+        使用<link linkend="auth-password"><acronym>SCRAM</acronym></link>认证时，增加使用通道绑定的功能 (Michael Paquier)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Channel binding is intended to prevent man-in-the-middle attacks, but
         <acronym>SCRAM</acronym> cannot prevent them unless it can be forced
         to be active.  Unfortunately, there is no way to do that in libpq.
         Support for it is expected in future versions of libpq and in
         interfaces not built using libpq, e.g. JDBC.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        通道绑定的目的是防止中间人攻击，但<acronym>SCRAM</acronym>无法阻止，除非它能被强制激活。不幸的是，在libpq中无法做到。期望在未来的libpq版本和不是由libpql构建的接口如JDBC中支持它。
        </para>
       </listitem>
 
@@ -4748,9 +7007,14 @@ same commits as above
 2018-04-05 [eed1ce72e] Allow background workers to bypass datallowconn
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow background workers to attach to databases that normally
         disallow connections (Magnus Hagander)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        允许后台工作者连接到通常不允许连接的数据库 (Magnus Hagander)
        </para>
       </listitem>
 
@@ -4759,9 +7023,15 @@ same commits as above
 2018-04-04 [f044d71e3] Use ARMv8 CRC instructions where available.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add support for hardware <acronym>CRC</acronym> calculations
         on <productname>ARMv8</productname> (Yuqi Gu, Heikki Linnakangas,
+        Thomas Munro)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        <productname>ARMv8</productname>上，增加硬件<acronym>CRC</acronym>计算的支持 (Yuqi Gu, Heikki Linnakangas,
         Thomas Munro)
        </para>
       </listitem>
@@ -4771,12 +7041,22 @@ same commits as above
 2017-10-04 [212e6f34d] Replace binary search in fmgr_isbuiltin with a lookup ar
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Speed up lookups of built-in functions by OID (Andres Freund)
        </para>
+____________________________________________________________________________-->
+       <para>
+        加速用OID对内置函数的查找 (Andres Freund)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         The previous binary search has been replaced by a lookup array.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        以前的二分法查找被替换为查找数组。
        </para>
       </listitem>
 
@@ -4785,8 +7065,13 @@ same commits as above
 2017-10-11 [1de09ad8e] Add more efficient functions to pqformat API.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Speed up construction of query results (Andres Freund)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        加速查询结果的构造 (Andres Freund)
        </para>
       </listitem>
 
@@ -4795,8 +7080,13 @@ same commits as above
 2017-10-13 [141fd1b66] Improve sys/catcache performance.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Improve speed of access to system caches (Andres Freund)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        改进系统缓存的访问速度 (Andres Freund)
        </para>
       </listitem>
 
@@ -4805,13 +7095,23 @@ same commits as above
 2017-11-23 [a4ccc1cef] Generational memory allocator
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add a generational memory allocator which is optimized for serial
         allocation/deallocation (Tomas Vondra)
        </para>
+____________________________________________________________________________-->
+       <para>
+        增加代内存分配器以对顺序的分配/释放进行优化 (Tomas Vondra)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This reduces memory usage for logical decoding.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        这样会减少逻辑解码的内存使用。
        </para>
       </listitem>
 
@@ -4820,11 +7120,16 @@ same commits as above
 2018-03-22 [7c91a0364] Sync up our various ways of estimating pg_class.reltuple
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Make the computation of
         <structname>pg_class</structname>.<structfield>reltuples</structfield>
         by <command>VACUUM</command> consistent with its computation
         by <command>ANALYZE</command> (Tomas Vondra)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        使<command>VACUUM</command>对 <structname>pg_class</structname>.<structfield>reltuples</structfield>的计算与<command>ANALYZE</command>对其的计算一致 (Tomas Vondra)
        </para>
       </listitem>
 
@@ -4834,9 +7139,14 @@ same commits as above
 2018-04-27 [a2ada08d4] perltidy: Don't write backup files
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Update to use <application>perltidy</application> version
         <literal>20170521</literal> (Tom Lane, Peter Eisentraut)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        升级以使用<application>perltidy</application>的版本<literal>20170521</literal> (Tom Lane, Peter Eisentraut)
        </para>
       </listitem>
 
@@ -4845,7 +7155,10 @@ same commits as above
    </sect3>
 
    <sect3>
+<!--==========================orignal english content==========================
     <title>Additional Modules</title>
+____________________________________________________________________________-->
+    <title>附加模块</title>
 
     <itemizedlist>
 
@@ -4854,17 +7167,27 @@ same commits as above
 2017-08-21 [79ccd7cbd] pg_prewarm: Add automatic prewarm feature.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow extension <link
         linkend="pgprewarm"><filename>pg_prewarm</filename></link>
         to restore the previous shared buffer contents on startup (Mithun
         Cy, Robert Haas)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许<link linkend="pgprewarm"><filename>pg_prewarm</filename></link>启动时恢复以前的共享缓冲区内容 (Mithun Cy, Robert Haas)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This is accomplished by having <filename>pg_prewarm</filename> store
         the shared buffers' relation and block number data to disk
         occasionally during server operation, and at shutdown.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        该功能实现的是让<filename>pg_prewarm</filename>在服务器运行期间和关闭时偶尔将共享缓冲区的关系和块数量的数据保存到磁盘。
        </para>
       </listitem>
 
@@ -4873,17 +7196,27 @@ same commits as above
 2018-03-21 [be8a7a686] Add strict_word_similarity to pg_trgm module
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add <link linkend="pgtrgm"><filename>pg_trgm</filename></link>
         function <function>strict_word_similarity()</function> to compute
         the similarity of whole words (Alexander Korotkov)
        </para>
+____________________________________________________________________________-->
+       <para>
+        增加<link linkend="pgtrgm"><filename>pg_trgm</filename></link>函数<function>strict_word_similarity()</function>以计算整个单词的相似性 (Alexander Korotkov)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         The function <function>word_similarity()</function> already
         existed for this purpose, but it was designed to find similar
         parts of words, while <function>strict_word_similarity()</function>
         computes the similarity to whole words.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        为此，已有函数<function>word_similarity()</function>，但其设计是为了找到单词相似的部分，而<function>strict_word_similarity()</function>则是计算整个单词的相似性。
        </para>
       </listitem>
 
@@ -4892,16 +7225,26 @@ same commits as above
 2017-09-19 [f24649976] Add citext_pattern_ops for citext contrib module
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow creation of indexes that can be used by <literal>LIKE</literal>
         comparisons
         on <link linkend="citext"><filename>citext</filename></link> columns
         (Alexey Chernyshov)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许创建能用于在<link linkend="citext"><filename>citext</filename></link>列上进行<literal>LIKE</literal>的索引 (Alexey Chernyshov)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         To do this, the index must be created using the
         <literal>citext_pattern_ops</literal> operator class.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        这样做的话，索引就必须用<literal>citext_pattern_ops</literal>操作符类创建。
        </para>
       </listitem>
 
@@ -4910,11 +7253,16 @@ same commits as above
 2018-04-05 [f4cd7102b] Add support of bool, bpchar, name and uuid to btree_gin
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow <link
         linkend="btree-gin"><filename>btree_gin</filename></link>
         to index <type>bool</type>, <type>bpchar</type>, <type>name</type>
         and <type>uuid</type> data types (Matheus Oliveira)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        允许<link linkend="btree-gin"><filename>btree_gin</filename></link>对<type>bool</type>, <type>bpchar</type>, <type>name</type>和<type>uuid</type>数据类型进行索引 (Matheus Oliveira)
        </para>
       </listitem>
 
@@ -4923,11 +7271,16 @@ same commits as above
 2017-11-20 [de1d042f5] Support index-only scans in contrib/cube and contrib/seg
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow <link linkend="cube"><filename>cube</filename></link>
         and <link linkend="seg"><filename>seg</filename></link>
         extensions to perform index-only scans using GiST indexes
         (Andrey Borodin)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        允许<link linkend="cube"><filename>cube</filename></link>和<link linkend="seg"><filename>seg</filename></link>扩展使用GiST索引执行仅索引扫描 (Andrey Borodin)
        </para>
       </listitem>
 
@@ -4936,14 +7289,24 @@ same commits as above
 2018-01-11 [f50c80dbb] llow negative coordinate for ~&gt; (cube, int) operator
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Allow retrieval of negative cube coordinates using
         the <literal>~&gt;</literal> operator (Alexander Korotkov)
        </para>
+____________________________________________________________________________-->
+       <para>
+        允许用<literal>~&gt;</literal>操作符接收负的立方体坐标 (Alexander Korotkov)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This is useful for KNN-GiST searches when looking for coordinates in
         descending order.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        这对在查找降序的坐标时做KNN-GiST搜索很有用。
        </para>
       </listitem>
 
@@ -4952,10 +7315,15 @@ same commits as above
 2017-08-16 [ec0a69e49] Extend the default rules file for contrib/unaccent with
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Add Vietnamese letter handling to the <link
         linkend="unaccent"><filename>unaccent</filename></link>
         extension (Dang Minh Huong, Michael Paquier)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        将越南文处理加到<link linkend="unaccent"><filename>unaccent</filename></link>扩展 (Dang Minh Huong, Michael Paquier)
        </para>
       </listitem>
 
@@ -4964,10 +7332,15 @@ same commits as above
 2018-03-31 [7f563c09f] Add amcheck verification of heap relations belonging to
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Enhance <link
         linkend="amcheck"><filename>amcheck</filename></link>
         to check that each heap tuple has an index entry (Peter Geoghegan)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        改进<link linkend="amcheck"><filename>amcheck</filename></link>，检查每个堆元组有无索引入口 (Peter Geoghegan)
        </para>
       </listitem>
 
@@ -4976,15 +7349,25 @@ same commits as above
 2018-04-06 [11523e860] Support new default roles with adminpack
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Have <link
         linkend="adminpack"><filename>adminpack</filename></link>
         use the new default file system access roles (Stephen Frost)
        </para>
+____________________________________________________________________________-->
+       <para>
+        使<link linkend="adminpack"><filename>adminpack</filename></link>使用新的缺省文件系统访问角色 (Stephen Frost)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         Previously, only superusers could call <filename>adminpack</filename>
         functions; now role permissions are checked.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        以前，只有超级用户才能调用<filename>adminpack</filename>函数；现在检查角色的权限。
        </para>
       </listitem>
 
@@ -4993,14 +7376,24 @@ same commits as above
 2017-10-11 [cff440d36] pg_stat_statements: Widen query IDs from 32 bits to 64 b
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Widen <structname>pg_stat_statement</structname>'s query ID
         to 64 bits (Robert Haas)
        </para>
+____________________________________________________________________________-->
+       <para>
+        将<structname>pg_stat_statement</structname>的查询ID增宽至64位 (Robert Haas)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This greatly reduces the chance of query ID hash collisions.
         The query ID can now potentially display as a negative value.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        这将大大减少查询ID出现哈希冲突的可能性。现在查询ID可能显示为负值。
        </para>
       </listitem>
 
@@ -5009,11 +7402,16 @@ same commits as above
 2017-11-17 [527878635] Remove contrib/start-scripts/osx/.
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Remove the <filename>contrib/start-scripts/osx</filename> scripts
         since they are no longer recommended
         (use <filename>contrib/start-scripts/macos</filename> instead)
         (Tom Lane)
+       </para>
+____________________________________________________________________________-->
+       <para>
+        移除<filename>contrib/start-scripts/osx</filename>脚本，因为其不再建议使用（<filename>contrib/start-scripts/macos</filename>代替） (Tom Lane)
        </para>
       </listitem>
 
@@ -5022,13 +7420,23 @@ same commits as above
 2017-09-22 [5d3cad564] Remove contrib/chkpass
 -->
 
+<!--==========================orignal english content==========================
        <para>
         Remove the <filename>chkpass</filename> extension (Peter Eisentraut)
        </para>
+____________________________________________________________________________-->
+       <para>
+        移除<filename>chkpass</filename>扩展 (Peter Eisentraut)
+       </para>
 
+<!--==========================orignal english content==========================
        <para>
         This extension is no longer considered to be a usable security tool
         or example of how to write an extension.
+       </para>
+____________________________________________________________________________-->
+       <para>
+        该扩展不再视为是一种有用的安全工具或如何编写扩展的示例。
        </para>
 
       </listitem>
@@ -5040,12 +7448,20 @@ same commits as above
   </sect2>
 
   <sect2 id="release-11-acknowledgements">
+<!--==========================orignal english content==========================
    <title>Acknowledgments</title>
+____________________________________________________________________________-->
+   <title>致谢</title>
 
+<!--==========================orignal english content==========================
    <para>
     The following individuals (in alphabetical order) have contributed to this
     release as patch authors, committers, reviewers, testers, or reporters of
     issues.
+   </para>
+____________________________________________________________________________-->
+   <para>
+    作为补丁的作者、提交者、审阅者、测试者或问题报告者，以下人员（按字母顺序排列）对该发行版做出了贡献。
    </para>
 
    <simplelist>


### PR DESCRIPTION
为保持PostgreSQL 11.2文档的完整性，完成了release-11.sgml的翻译 。