### PR TITLE
Fix#263:翻译SQL命令CREATE POLICY未翻译的部分

### DIFF
--- a/postgresql/doc/src/sgml/ref/create_policy.sgml
+++ b/postgresql/doc/src/sgml/ref/create_policy.sgml
@@ -571,15 +571,7 @@ ____________________________________________________________________________-->
        </para>
 ____________________________________________________________________________-->
        <para>
-         为一条策略使用<literal>UPDATE</literal>表示它适用于
-         <literal>UPDATE</literal>、<literal>SELECT FOR UPDATE</literal>和<literal>SELECT FOR SHARE</literal>命令，还有<literal>INSERT</literal>命令的辅助性的<literal>ON CONFLICT DO UPDATE</literal>子句。===Since <literal>UPDATE</literal>
-         involves pulling an existing record and replacing it with a new
-         modified record, <literal>UPDATE</literal>
-         policies accept both a <literal>USING</literal> expression and
-         a <literal>WITH CHECK</literal> expression.。<literal>USING</literal>
-         表达式决定<literal>UPDATE</literal>命令将能看到哪些要对其操作
-         的记录，而<literal>WITH CHECK</literal>表达式定义哪些被修改的
-         行被允许存回到关系中。
+         对策略使用<literal>UPDATE</literal> 意味着它将应用于<literal>UPDATE</literal>、<literal>SELECT FOR UPDATE</literal>和<literal>SELECT FOR SHARE</literal> 命令，还有<literal>INSERT</literal> 命令的辅助性的<literal>ON CONFLICT DO UPDATE</literal> 子句。由于<literal>UPDATE</literal> 需要提取现有的记录并且用新修改的记录代替，故<literal>UPDATE</literal> 策略接受<literal>USING</literal> 表达式和<literal>WITH CHECK</literal> 表达式。<literal>USING</literal> 表达式决定<literal>UPDATE</literal> 命令将能看到哪些要对其操作的记录，而<literal>WITH CHECK</literal> 表达式定义哪些被修改的行允许存回到关系中。
        </para>
 
 <!--==========================orignal english content==========================
@@ -616,19 +608,7 @@ ____________________________________________________________________________-->
        </para>
 ____________________________________________________________________________-->
        <para>
-         ===Typically an <literal>UPDATE</literal> command also needs to read
-         data from columns in the relation being updated (e.g., in a
-         <literal>WHERE</literal> clause or a <literal>RETURNING</literal>
-         clause, or in an expression on the right hand side of the
-         <literal>SET</literal> clause).  In this case,
-         <literal>SELECT</literal> rights are also required on the relation
-         being updated, and the appropriate <literal>SELECT</literal> or
-         <literal>ALL</literal> policies will be applied in addition to
-         the <literal>UPDATE</literal> policies.  Thus the user must have
-         access to the row(s) being updated through a <literal>SELECT</literal>
-         or <literal>ALL</literal> policy in addition to being granted
-         permission to update the row(s) via an <literal>UPDATE</literal>
-         or <literal>ALL</literal> policy.
+         典型地，<literal>UPDATE</literal>命令也需要从待更新关系中的列读数据（例如在<literal>WHERE</literal>子句、<literal>RETURNING</literal>子句或在<literal>SET</literal>子句右侧的表达式中）。这种情况下，正被更新的关系上也需要<literal>SELECT</literal>权限，并且除了<literal>UPDATE</literal>策略外，也要应用适当的<literal>SELECT</literal>或者<literal>ALL</literal>策略。这样，除由<literal>UPDATE</literal>或<literal>ALL</literal>策略授权更新行之外，通过<literal>SELECT</literal>或<literal>ALL</literal>策略用也必须能访问正被更新的行。
        </para>
 
 <!--==========================orignal english content==========================
@@ -647,17 +627,7 @@ ____________________________________________________________________________-->
        </para>
 ____________________________________________________________________________-->
        <para>
-         ===When an <literal>INSERT</literal> command has an auxiliary
-         <literal>ON CONFLICT DO UPDATE</literal> clause, if the
-         <literal>UPDATE</literal> path is taken, the row to be updated is
-         first checked against the <literal>USING</literal> expressions of
-         any <literal>UPDATE</literal> policies, and then the new updated row
-         is checked against the <literal>WITH CHECK</literal> expressions.
-         Note, however, that unlike a standalone <literal>UPDATE</literal>
-         command, if the existing row does not pass the
-         <literal>USING</literal> expressions, an error will be thrown (the
-         <literal>UPDATE</literal> path will <emphasis>never</emphasis> be silently
-         avoided).
+         当<literal>INSERT</literal>命令附加了<literal>ON CONFLICT DO UPDATE</literal>子句时，如果采用<literal>UPDATE</literal>路径，先以任何<literal>UPDATE</literal>策略的<literal>USING</literal>表达式检查待更新的行，然后以<literal>WITH CHECK</literal>表达式检查新修改的行。但要注意的是，不同于单独的<literal>UPDATE</literal>命令，如果现有的行不能通过<literal>USING</literal>表达式检查，则抛出错误（<literal>UPDATE</literal>路径<emphasis>永不</emphasis>会静默地避免）。
        </para>
       </listitem>
      </varlistentry>
@@ -704,18 +674,7 @@ ____________________________________________________________________________-->
        </para>
 ____________________________________________________________________________-->
        <para>
-         ===In most cases a <literal>DELETE</literal> command also needs to read
-         data from columns in the relation that it is deleting from (e.g.,
-         in a <literal>WHERE</literal> clause or a
-         <literal>RETURNING</literal> clause). In this case,
-         <literal>SELECT</literal> rights are also required on the relation,
-         and the appropriate <literal>SELECT</literal> or
-         <literal>ALL</literal> policies will be applied in addition to
-         the <literal>DELETE</literal> policies.  Thus the user must have
-         access to the row(s) being deleted through a <literal>SELECT</literal>
-         or <literal>ALL</literal> policy in addition to being granted
-         permission to delete the row(s) via a <literal>DELETE</literal> or
-         <literal>ALL</literal> policy.
+         大多数情况下，<literal>DELETE</literal>命令也需要从其所删除的关系中的列读取数据（例如在<literal>WHERE</literal>子句或<literal>RETURNING</literal>子句中）。这种情况下，在该关系上也需要<literal>SELECT</literal>权限，并且除了<literal>DELETE</literal>策略，也要应用适当的<literal>SELECT</literal>或<literal>ALL</literal>策略。这样，除由<literal>DELETE</literal>或<literal>ALL</literal>策略授权删除行之外，通过<literal>SELECT</literal>或<literal>ALL</literal>策略，用户也必须能访问正被删除的行。
        </para>
 
 <!--==========================orignal english content==========================
@@ -740,7 +699,7 @@ ____________________________________________________________________________-->
 <!--==========================orignal english content==========================
     <title>Policies Applied by Command Type</title>
 ____________________________________________________________________________-->
-    <title>===Policies Applied by Command Type</title>
+    <title>按命令类型应用的策略</title>
     <tgroup cols="6">
      <colspec colnum="4" colname="update-using"/>
      <colspec colnum="5" colname="update-check"/>
@@ -756,11 +715,11 @@ ____________________________________________________________________________-->
       </row>
 ____________________________________________________________________________-->
       <row>
-       <entry morerows="1">Command</entry>
-       <entry><literal>SELECT/ALL policy</literal></entry>
-       <entry><literal>INSERT/ALL policy</literal></entry>
-       <entry spanname="update"><literal>UPDATE/ALL policy</literal></entry>
-       <entry><literal>DELETE/ALL policy</literal></entry>
+       <entry morerows="1">命令</entry>
+       <entry><literal>SELECT/ALL策略</literal></entry>
+       <entry><literal>INSERT/ALL策略</literal></entry>
+       <entry spanname="update"><literal>UPDATE/ALL策略</literal></entry>
+       <entry><literal>DELETE/ALL策略</literal></entry>
       </row>
 <!--==========================orignal english content==========================
       <row>
@@ -772,11 +731,11 @@ ____________________________________________________________________________-->
       </row>
 ____________________________________________________________________________-->
       <row>
-       <entry><literal>USING expression</literal></entry>
-       <entry><literal>WITH CHECK expression</literal></entry>
-       <entry><literal>USING expression</literal></entry>
-       <entry><literal>WITH CHECK expression</literal></entry>
-       <entry><literal>USING expression</literal></entry>
+       <entry><literal>USING表达式</literal></entry>
+       <entry><literal>WITH CHECK表达式</literal></entry>
+       <entry><literal>USING表达式</literal></entry>
+       <entry><literal>WITH CHECK表达式</literal></entry>
+       <entry><literal>USING表达式</literal></entry>
       </row>
      </thead>
      <tbody>
@@ -792,7 +751,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
       <row>
        <entry><command>SELECT</command></entry>
-       <entry>Existing row</entry>
+       <entry>现有行</entry>
        <entry>&mdash;</entry>
        <entry>&mdash;</entry>
        <entry>&mdash;</entry>
@@ -810,9 +769,9 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
       <row>
        <entry><command>SELECT FOR UPDATE/SHARE</command></entry>
-       <entry>Existing row</entry>
+       <entry>现有行</entry>
        <entry>&mdash;</entry>
-       <entry>Existing row</entry>
+       <entry>现有行</entry>
        <entry>&mdash;</entry>
        <entry>&mdash;</entry>
       </row>
@@ -829,7 +788,7 @@ ____________________________________________________________________________-->
       <row>
        <entry><command>INSERT</command></entry>
        <entry>&mdash;</entry>
-       <entry>New row</entry>
+       <entry>新行</entry>
        <entry>&mdash;</entry>
        <entry>&mdash;</entry>
        <entry>&mdash;</entry>
@@ -855,15 +814,13 @@ ____________________________________________________________________________-->
       <row>
        <entry><command>INSERT ... RETURNING</command></entry>
        <entry>
-        ===New row <footnote id="rls-select-priv">
+        新行<footnote id="rls-select-priv">
          <para>
-          ===If read access is required to the existing or new row (for example,
-          a <literal>WHERE</literal> or <literal>RETURNING</literal> clause
-          that refers to columns from the relation).
+          对于现有行或新行，如果需要读访问的话（例如涉及到关系内列的<literal>WHERE</literal>或<literal>RETURNING</literal>子句）。
          </para>
         </footnote>
        </entry>
-       <entry>New row</entry>
+       <entry>新行</entry>
        <entry>&mdash;</entry>
        <entry>&mdash;</entry>
        <entry>&mdash;</entry>
@@ -883,11 +840,11 @@ ____________________________________________________________________________-->
       <row>
        <entry><command>UPDATE</command></entry>
        <entry>
-        ===Existing &amp; new rows <footnoteref linkend="rls-select-priv"/>
+        现有 &amp; 新行 <footnoteref linkend="rls-select-priv"/>
        </entry>
        <entry>&mdash;</entry>
-       <entry>Existing row</entry>
-       <entry>New row</entry>
+       <entry>现有行</entry>
+       <entry>新行</entry>
        <entry>&mdash;</entry>
       </row>
 <!--==========================orignal english content==========================
@@ -905,12 +862,12 @@ ____________________________________________________________________________-->
       <row>
        <entry><command>DELETE</command></entry>
        <entry>
-        ===Existing row <footnoteref linkend="rls-select-priv"/>
+        现有行<footnoteref linkend="rls-select-priv"/>
        </entry>
        <entry>&mdash;</entry>
        <entry>&mdash;</entry>
        <entry>&mdash;</entry>
-       <entry>Existing row</entry>
+       <entry>现有行</entry>
       </row>
 <!--==========================orignal english content==========================
       <row>
@@ -924,10 +881,10 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
       <row>
        <entry><command>ON CONFLICT DO UPDATE</command></entry>
-       <entry>===Existing &amp; new rows</entry>
+       <entry>现有 &amp; 新行</entry>
        <entry>&mdash;</entry>
-       <entry>Existing row</entry>
-       <entry>New row</entry>
+       <entry>现有行</entry>
+       <entry>新行</entry>
        <entry>&mdash;</entry>
       </row>
      </tbody>
@@ -940,7 +897,7 @@ ____________________________________________________________________________-->
 <!--==========================orignal english content==========================
    <title>Application of Multiple Policies</title>
 ____________________________________________________________________________-->
-   <title>===Application of Multiple Policies</title>
+   <title>多重策略的应用</title>
 
 <!--==========================orignal english content==========================
    <para>
@@ -954,13 +911,7 @@ ____________________________________________________________________________-->
    </para>
 ____________________________________________________________________________-->
    <para>
-    ===When multiple policies of different command types apply to the same command
-    (for example, <literal>SELECT</literal> and <literal>UPDATE</literal>
-    policies applied to an <literal>UPDATE</literal> command), then the user
-    must have both types of permissions (for example, permission to select rows
-    from the relation as well as permission to update them).  Thus the
-    expressions for one type of policy are combined with the expressions for
-    the other type of policy using the <literal>AND</literal> operator.
+    当多种不同命令类型的策略应用于相同命令（例如<literal>SELECT</literal>和<literal>UPDATE</literal>策略应用于<literal>UPDATE</literal>命令）时，用户就必须同时具有这两种类型的权限（例如从关系中选取行和更新的权限）。这样一种策略类型的表达式就与另一种策略类型的表达式通过使用<literal>AND</literal>操作符组合在一起。
    </para>
 
 <!--==========================orignal english content==========================
@@ -977,15 +928,7 @@ ____________________________________________________________________________-->
    </para>
 ____________________________________________________________________________-->
    <para>
-    ===When multiple policies of the same command type apply to the same command,
-    then there must be at least one <literal>PERMISSIVE</literal> policy
-    granting access to the relation, and all of the
-    <literal>RESTRICTIVE</literal> policies must pass.  Thus all the
-    <literal>PERMISSIVE</literal> policy expressions are combined using
-    <literal>OR</literal>, all the <literal>RESTRICTIVE</literal> policy
-    expressions are combined using <literal>AND</literal>, and the results are
-    combined using <literal>AND</literal>.  If there are no
-    <literal>PERMISSIVE</literal> policies, then access is denied.
+    当相同命令类型的多种策略应用于同一命令时，则必须至少有一个<literal>PERMISSIVE</literal>策略授权对该关系的访问，所有的<literal>RESTRICTIVE</literal>策略必须通过。这样，所有的<literal>PERMISSIVE</literal>策略表达式都用<literal>OR</literal>来组合，所有的<literal>RESTRICTIVE</literal>策略表达式都用<literal>AND</literal>来组合，而结果用<literal>AND</literal>来组合。如果没有<literal>PERMISSIVE</literal>策略，则拒绝访问。
    </para>
 
 <!--==========================orignal english content==========================
@@ -996,9 +939,7 @@ ____________________________________________________________________________-->
    </para>
 ____________________________________________________________________________-->
    <para>
-    ===Note that, for the purposes of combining multiple policies,
-    <literal>ALL</literal> policies are treated as having the same type as
-    whichever other type of policy is being applied.
+    要注意的是，出于组合多种策略的目的，将<literal>ALL</literal>策略视为与所应用的任何其他类型的策略具有相同的类型。
    </para>
 
 <!--==========================orignal english content==========================
@@ -1039,10 +980,7 @@ AND
 </programlisting></para>
 ____________________________________________________________________________-->
    <para>
-    ===For example, in an <literal>UPDATE</literal> command requiring both
-    <literal>SELECT</literal> and <literal>UPDATE</literal> permissions, if
-    there are multiple applicable policies of each type, they will be combined
-    as follows:
+    例如，在<literal>UPDATE</literal>命令中，<literal>SELECT</literal>和<literal>UPDATE</literal>两种权限都需要，如果每种类型都有多个适用的策略，则将之以下面的方式组合：
 
 <programlisting>
 <replaceable>expression</replaceable> from RESTRICTIVE SELECT/ALL policy 1


### PR DESCRIPTION
解决Issue#263所描述的问题。对应原来的XML文件为ref/create_policy.sgml，自576行开始，至1045行。

参见Issue详情：https://github.com/postgres-cn/pgdoc-cn/issues/263