### PR TITLE
Fix:表C.1.SQL关键词PostgreSQL栏翻译不完全，且生成PDF列宽度不合适

### DIFF
--- a/postgresql/doc/src/sgml/keywords.sgml
+++ b/postgresql/doc/src/sgml/keywords.sgml
@@ -129,6 +129,11 @@ ____________________________________________________________________________-->
  <title><acronym>SQL</acronym>关键词</title>
 
  <tgroup cols="5">
+  <colspec colnum="1" colname="col1" colwidth="3.3*"/>
+  <colspec colnum="2" colname="col2" colwidth="3.7*"/>
+  <colspec colnum="3" colname="col3" colwidth="1.4*"/>
+  <colspec colnum="4" colname="col4" colwidth="1.4*"/>
+  <colspec colnum="5" colname="col5" colwidth="1.2*"/>
   <thead>
 <!--==========================orignal english content==========================
    <row>
@@ -752,7 +757,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>AUTHORIZATION</token></entry>
-    <entry>reserved (can be function or type)</entry>
+    <entry>保留（可以是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -896,7 +901,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>BETWEEN</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -912,7 +917,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>BIGINT</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry></entry>
@@ -928,7 +933,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>BINARY</token></entry>
-    <entry>reserved (can be function or type)</entry>
+    <entry>保留（可以是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry></entry>
@@ -944,7 +949,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>BIT</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry></entry>
     <entry></entry>
     <entry>保留</entry>
@@ -1024,7 +1029,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>BOOLEAN</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry></entry>
@@ -1312,7 +1317,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>CHAR</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -1328,7 +1333,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>CHARACTER</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -1568,7 +1573,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>COALESCE</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -1616,7 +1621,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>COLLATION</token></entry>
-    <entry>reserved (can be function or type)</entry>
+    <entry>保留（可以是函数或类型）</entry>
     <entry>非保留</entry>
     <entry>非保留</entry>
     <entry>保留</entry>
@@ -1840,7 +1845,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>CONCURRENTLY</token></entry>
-    <entry>reserved (can be function or type)</entry>
+    <entry>保留（可以是函数或类型）</entry>
     <entry></entry>
     <entry></entry>
     <entry></entry>
@@ -2288,7 +2293,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>CROSS</token></entry>
-    <entry>reserved (can be function or type)</entry>
+    <entry>保留（可以是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -2464,7 +2469,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>CURRENT_SCHEMA</token></entry>
-    <entry>reserved (can be function or type)</entry>
+    <entry>保留（可以是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry></entry>
@@ -2736,7 +2741,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>DEC</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -2752,7 +2757,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>DECIMAL</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -3904,7 +3909,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>EXISTS</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -4000,7 +4005,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>EXTRACT</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -4160,7 +4165,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>FLOAT</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -4336,7 +4341,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>FREEZE</token></entry>
-    <entry>reserved (can be function or type)</entry>
+    <entry>保留（可以是函数或类型）</entry>
     <entry></entry>
     <entry></entry>
     <entry></entry>
@@ -4384,7 +4389,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>FULL</token></entry>
-    <entry>reserved (can be function or type)</entry>
+    <entry>保留（可以是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -4592,7 +4597,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>GREATEST</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry></entry>
     <entry></entry>
     <entry></entry>
@@ -4624,7 +4629,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>GROUPING</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry></entry>
@@ -4832,7 +4837,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>ILIKE</token></entry>
-    <entry>reserved (can be function or type)</entry>
+    <entry>保留（可以是函数或类型）</entry>
     <entry></entry>
     <entry></entry>
     <entry></entry>
@@ -5136,7 +5141,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>INNER</token></entry>
-    <entry>reserved (can be function or type)</entry>
+    <entry>保留（可以是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -5152,7 +5157,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>INOUT</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry></entry>
@@ -5264,7 +5269,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>INT</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -5280,7 +5285,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>INTEGER</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -5344,7 +5349,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>INTERVAL</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -5392,7 +5397,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>IS</token></entry>
-    <entry>reserved (can be function or type)</entry>
+    <entry>保留（可以是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -5408,7 +5413,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>ISNULL</token></entry>
-    <entry>reserved (can be function or type)</entry>
+    <entry>保留（可以是函数或类型）</entry>
     <entry></entry>
     <entry></entry>
     <entry></entry>
@@ -5440,7 +5445,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>JOIN</token></entry>
-    <entry>reserved (can be function or type)</entry>
+    <entry>保留（可以是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -5680,7 +5685,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>LEAST</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry></entry>
     <entry></entry>
     <entry></entry>
@@ -5696,7 +5701,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>LEFT</token></entry>
-    <entry>reserved (can be function or type)</entry>
+    <entry>保留（可以是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -5760,7 +5765,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>LIKE</token></entry>
-    <entry>reserved (can be function or type)</entry>
+    <entry>保留（可以是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -6496,7 +6501,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>NATIONAL</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -6512,7 +6517,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>NATURAL</token></entry>
-    <entry>reserved (can be function or type)</entry>
+    <entry>保留（可以是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -6528,7 +6533,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>NCHAR</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -6704,7 +6709,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>NONE</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry></entry>
@@ -6800,7 +6805,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>NOTNULL</token></entry>
-    <entry>reserved (can be function or type)</entry>
+    <entry>保留（可以是函数或类型）</entry>
     <entry></entry>
     <entry></entry>
     <entry></entry>
@@ -6896,7 +6901,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>NULLIF</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -6944,7 +6949,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>NUMERIC</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -7280,7 +7285,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>OUT</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry></entry>
@@ -7296,7 +7301,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>OUTER</token></entry>
-    <entry>reserved (can be function or type)</entry>
+    <entry>保留（可以是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -7344,7 +7349,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>OVERLAPS</token></entry>
-    <entry>reserved (can be function or type)</entry>
+    <entry>保留（可以是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -7360,7 +7365,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>OVERLAY</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry></entry>
@@ -7888,7 +7893,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>POSITION</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -7968,7 +7973,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>PRECISION</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -8256,7 +8261,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>REAL</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -8896,7 +8901,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>RIGHT</token></entry>
-    <entry>reserved (can be function or type)</entry>
+    <entry>保留（可以是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -9040,7 +9045,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>ROW</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry></entry>
@@ -9536,7 +9541,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>SETOF</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry></entry>
     <entry></entry>
     <entry></entry>
@@ -9600,7 +9605,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>SIMILAR</token></entry>
-    <entry>reserved (can be function or type)</entry>
+    <entry>保留（可以是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry></entry>
@@ -9664,7 +9669,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>SMALLINT</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -10208,7 +10213,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>SUBSTRING</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -10400,7 +10405,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>TABLESAMPLE</token></entry>
-    <entry>reserved (can be function or type)</entry>
+    <entry>保留（可以是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry></entry>
@@ -10544,7 +10549,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>TIME</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -10560,7 +10565,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>TIMESTAMP</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -10816,7 +10821,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>TREAT</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry></entry>
@@ -10896,7 +10901,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>TRIM</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -11488,7 +11493,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>VALUES</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -11536,7 +11541,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>VARCHAR</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry>保留</entry>
@@ -11616,7 +11621,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>VERBOSE</token></entry>
-    <entry>reserved (can be function or type)</entry>
+    <entry>保留（可以是函数或类型）</entry>
     <entry></entry>
     <entry></entry>
     <entry></entry>
@@ -11936,7 +11941,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>XMLATTRIBUTES</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry></entry>
@@ -12000,7 +12005,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>XMLCONCAT</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry></entry>
@@ -12048,7 +12053,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>XMLELEMENT</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry></entry>
@@ -12064,7 +12069,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>XMLEXISTS</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry></entry>
@@ -12080,7 +12085,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>XMLFOREST</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry></entry>
@@ -12112,7 +12117,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>XMLNAMESPACES</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry></entry>
@@ -12128,7 +12133,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>XMLPARSE</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry></entry>
@@ -12144,7 +12149,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>XMLPI</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry></entry>
@@ -12176,7 +12181,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>XMLROOT</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry></entry>
     <entry></entry>
     <entry></entry>
@@ -12208,7 +12213,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>XMLSERIALIZE</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry></entry>
@@ -12224,7 +12229,7 @@ ____________________________________________________________________________-->
 ____________________________________________________________________________-->
    <row>
     <entry><token>XMLTABLE</token></entry>
-    <entry>non-reserved (cannot be function or type)</entry>
+    <entry>非保留（不能是函数或类型）</entry>
     <entry>保留</entry>
     <entry>保留</entry>
     <entry></entry>


### PR DESCRIPTION
表C.1.SQL关键词PostgreSQL栏翻译不完全，且表格中单元格关键词字符串长度过长会导致生成PDF字符串越出单元格边界，翻译并添加colwidth调整表格各列比例确保生成PDF各列正常显示，不影响生成HTML的显示效果。