### PR TITLE
翻译8.1.2:plus three to eight bytes overhead

### DIFF
--- a/postgresql/doc/src/sgml/datatype.sgml
+++ b/postgresql/doc/src/sgml/datatype.sgml
@@ -1142,8 +1142,7 @@ ____________________________________________________________________________-->
     </para>
 ____________________________________________________________________________-->
     <para>
-     数字值在物理上是以不带任何前导或者后缀零的形式存储。 因此，列上声明的精度和比例都是最大值，而不是固定分配的 （在这个方面，<type>numeric</type>类型更类似于<type>varchar(<replaceable>n</replaceable>)</type>， 而不像<type>char(<replaceable>n</replaceable>)</type>）。 实际存储要求是每四个十进制位组用两个字节，
-     plus three to eight bytes overhead.
+     数字值在物理上是以不带任何前导或者后缀零的形式存储。 因此，列上声明的精度和比例都是最大值，而不是固定分配的 （在这个方面，<type>numeric</type>类型更类似于<type>varchar(<replaceable>n</replaceable>)</type>， 而不像<type>char(<replaceable>n</replaceable>)</type>）。 实际存储要求是每四个十进制位组用两个字节，再加上三到八个字节的开销。
     </para>
 
 <!--==========================orignal english content==========================


### PR DESCRIPTION
将8.1.2:plus three to eight bytes overhead翻译为：外加三到八个字节的开销。