### PR TITLE
翻译有误, PQsetSingleRowMode 应该在 PQsendQuery 之后调用

### DIFF
--- a/postgresql/doc/src/sgml/libpq.sgml
+++ b/postgresql/doc/src/sgml/libpq.sgml
@@ -8403,7 +8403,7 @@ ____________________________________________________________________________-->
   </para>
 ____________________________________________________________________________-->
   <para>
-   要进入到单行模式，在一次成功的<xref linkend="libpq-PQsetSingleRowMode"/>（或者其他兄弟函数）调用后立即调用<xref linkend="libpq-PQsendQuery"/>。
+   要进入到单行模式，需要在成功调用<xref linkend="libpq-PQsendQuery"/>(或兄弟函数)之后立即调用<xref linkend="libpq-PQsetSingleRowMode"/>。
    这种模式选择只对当前正在执行的查询有效。然后反复调用<xref linkend="libpq-PQgetResult"/>，直到它返回空，如<xref linkend="libpq-async"/>中所示。
    如果该查询返回行，它们会作为单个的<structname>PGresult</structname>对象返回，它们看起来都像普通的查询结果，只不过其状态代码是<literal>PGRES_SINGLE_TUPLE</literal>而非<literal>PGRES_TUPLES_OK</literal>。
    在最后一行之后或者紧接着该查询返回零行之后，一个状态为<literal>PGRES_TUPLES_OK</literal>的零行对象会被返回，这就是代表不会有更多行的信号（但是注意仍然有必要继续调用<xref linkend="libpq-PQgetResult"/>直到它返回空）。


### PR DESCRIPTION
英文原文是: call PQsetSingleRowMode immediately after a successful call of PQsendQuery (or a sibling function);
代码测试下也是 PQsetSingleRowMode(conn) 应该在 PQsendQuery(conn, cmd) 后调用;

# PQsetSingleRowMode(conn) 设置成功返回1, 失败返回0, 测试代码如下:
// 成功: ok 得 1;
int ok = PQsendQuery(conn, cmd.data());
ok = PQsetSingleRowMode(conn);
std::cout << std::format("设单行结果: {}\n", ok);

// 反过来后再运行: 失败: ok 得 0:
int ok = PQsetSingleRowMode(conn);
std::cout << std::format("设单行结果: {}\n", ok);
ok = PQsendQuery(conn, cmd.data());
