### PR TITLE
fix typo in create_rule.sgml 

### DIFF
--- a/postgresql/doc/src/sgml/ref/create_rule.sgml
+++ b/postgresql/doc/src/sgml/ref/create_rule.sgml
@@ -261,7 +261,7 @@ ____________________________________________________________________________-->
      </para>
 ____________________________________________________________________________-->
      <para>
-      时间是<literal>SELECT</literal>、
+      事件是<literal>SELECT</literal>、
       <literal>INSERT</literal>、<literal>UPDATE</literal>或者
       <literal>DELETE</literal>之一。 注意包含<literal>ON
       CONFLICT</literal>子句的<command>INSERT</command>


### PR DESCRIPTION
event的翻译由"时间"改为"事件"